### PR TITLE
Use metadata_options for tag/category options

### DIFF
--- a/template-jwt/index.html
+++ b/template-jwt/index.html
@@ -11,6 +11,20 @@
   <div class="container py-4">
     <h1 class="text-center mb-4">Video Categories</h1>
 
+    <div class="row mb-3 g-2 align-items-end">
+      <div class="col-md-4">
+        <label for="categoryFilter" class="form-label">Category</label>
+        <select id="categoryFilter" class="form-select"></select>
+      </div>
+      <div class="col-md-4">
+        <label for="tagFilter" class="form-label">Tag</label>
+        <select id="tagFilter" class="form-select"></select>
+      </div>
+      <div class="col-md-4">
+        <button id="applyFilters" class="btn btn-primary w-100">Apply Filters</button>
+      </div>
+    </div>
+
     <div id="categories"></div>
   </div>
 
@@ -19,7 +33,18 @@
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const container = document.getElementById('categories');
+      const categorySelect = document.getElementById('categoryFilter');
+      const tagSelect = document.getElementById('tagFilter');
+      loadCategoryOptions(categorySelect);
+      loadTagOptions(tagSelect);
       loadFileListByFolder(container);
+
+      document.getElementById('applyFilters').addEventListener('click', () => {
+        container.innerHTML = '';
+        const category = categorySelect.value;
+        const tag = tagSelect.value;
+        loadFileListByFolder(container, { category, tag });
+      });
     });
   </script>
 </body>

--- a/template-jwt/script.js
+++ b/template-jwt/script.js
@@ -34,7 +34,17 @@ async function fetchMetadataOptions() {
     throw new Error(`HTTP ${res.status}`);
   }
   const data = await res.json();
-  METADATA_OPTIONS = data.metadata_keys || {};
+  const meta = {};
+  if (data && data.metadata_keys) {
+    const keys = data.metadata_keys;
+    if (keys.category && Array.isArray(keys.category.unique_values)) {
+      meta.category = keys.category.unique_values;
+    }
+    if (keys.tags && Array.isArray(keys.tags.unique_values)) {
+      meta.tags = keys.tags.unique_values;
+    }
+  }
+  METADATA_OPTIONS = meta;
   return METADATA_OPTIONS;
 }
 

--- a/template-jwt/script.js
+++ b/template-jwt/script.js
@@ -2,6 +2,10 @@
 const API_HOST = 'filma-dev.xcream.net';
 // この API キーは JWT 発行時のみ使用します
 const API_KEY = 'e47aad55d7fb4f152603b91b';
+// show_allパラメータを付与するかどうかを設定
+// trueにするとAPIリクエストに`show_all=true`が付き、fullaccess権限のAPIキー利用時は
+// 非公開ファイルも取得できます (詳細は api_specification.md 参照)
+const USE_SHOW_ALL = false;
 
 // JWT 取得用関数を生成
 function createJwtTokenFetcher(apiHost, apiKey) {
@@ -30,14 +34,9 @@ function createJwtTokenFetcher(apiHost, apiKey) {
     return jwtTokenPromise;
   };
 }
-
-// 使用例
 const getJwtToken = createJwtTokenFetcher(API_HOST, API_KEY);
-// show_allパラメータを付与するかどうかを設定
-// trueにするとAPIリクエストに`show_all=true`が付き、fullaccess権限のAPIキー利用時は
-// 非公開ファイルも取得できます (詳細は api_specification.md 参照)
-const USE_SHOW_ALL = false;
 
+// メタデータ取得関数を生成
 function createMetadataOptionsFetcher(apiHost, getToken) {
   let metadataOptions = null;
   let metadataOptionsPromise = null;
@@ -73,8 +72,6 @@ function createMetadataOptionsFetcher(apiHost, getToken) {
     return metadataOptionsPromise;
   };
 }
-
-// メタデータ取得関数を生成
 const fetchMetadataOptions = createMetadataOptionsFetcher(API_HOST, getJwtToken);
 
 // カテゴリ一覧を取得して<select>要素に追加

--- a/template-no-auth/index.html
+++ b/template-no-auth/index.html
@@ -11,6 +11,20 @@
   <div class="container py-4">
     <h1 class="text-center mb-4">Video Categories</h1>
 
+    <div class="row mb-3 g-2 align-items-end">
+      <div class="col-md-4">
+        <label for="categoryFilter" class="form-label">Category</label>
+        <select id="categoryFilter" class="form-select"></select>
+      </div>
+      <div class="col-md-4">
+        <label for="tagFilter" class="form-label">Tag</label>
+        <select id="tagFilter" class="form-select"></select>
+      </div>
+      <div class="col-md-4">
+        <button id="applyFilters" class="btn btn-primary w-100">Apply Filters</button>
+      </div>
+    </div>
+
     <div id="categories"></div>
   </div>
 
@@ -19,7 +33,18 @@
   <script>
     window.addEventListener('DOMContentLoaded', () => {
       const container = document.getElementById('categories');
+      const categorySelect = document.getElementById('categoryFilter');
+      const tagSelect = document.getElementById('tagFilter');
+      loadCategoryOptions(categorySelect);
+      loadTagOptions(tagSelect);
       loadFileListByFolder(container);
+
+      document.getElementById('applyFilters').addEventListener('click', () => {
+        container.innerHTML = '';
+        const category = categorySelect.value;
+        const tag = tagSelect.value;
+        loadFileListByFolder(container, { category, tag });
+      });
     });
   </script>
 </body>

--- a/template-no-auth/script.js
+++ b/template-no-auth/script.js
@@ -6,6 +6,7 @@ const API_KEY = 'e47aad55d7fb4f152603b91b';
 // 非公開ファイルも取得できます (詳細は api_specification.md 参照)
 const USE_SHOW_ALL = false;
 
+// メタデータ取得関数を生成
 function createMetadataOptionsFetcher(apiHost, apiKey) {
   let metadataOptions = null;
   let metadataOptionsPromise = null;
@@ -40,7 +41,6 @@ function createMetadataOptionsFetcher(apiHost, apiKey) {
     return metadataOptionsPromise;
   };
 }
-
 const fetchMetadataOptions = createMetadataOptionsFetcher(API_HOST, API_KEY);
 
 // カテゴリ一覧を取得して<select>要素に追加

--- a/template-no-auth/script.js
+++ b/template-no-auth/script.js
@@ -6,6 +6,67 @@ const API_KEY = 'e47aad55d7fb4f152603b91b';
 // 非公開ファイルも取得できます (詳細は api_specification.md 参照)
 const USE_SHOW_ALL = false;
 
+let METADATA_OPTIONS = null;
+
+// メタデータオプションを取得
+async function fetchMetadataOptions() {
+  if (METADATA_OPTIONS) return METADATA_OPTIONS;
+  const url = `https://${API_HOST}/filmaapi/storage/metadata_options?api_key=${encodeURIComponent(API_KEY)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  const data = await res.json();
+  const meta = {};
+  if (data && data.metadata_keys) {
+    const keys = data.metadata_keys;
+    if (keys.category && Array.isArray(keys.category.unique_values)) {
+      meta.category = keys.category.unique_values;
+    }
+    if (keys.tags && Array.isArray(keys.tags.unique_values)) {
+      meta.tags = keys.tags.unique_values;
+    }
+  }
+  METADATA_OPTIONS = meta;
+  return METADATA_OPTIONS;
+}
+
+// カテゴリ一覧を取得して<select>要素に追加
+async function loadCategoryOptions(select) {
+  if (!select) return;
+  try {
+    const options = await fetchMetadataOptions();
+    const list = Array.isArray(options.category) ? options.category : [];
+    select.innerHTML = '<option value="">All</option>';
+    list.forEach(name => {
+      const option = document.createElement('option');
+      option.value = name;
+      option.textContent = name;
+      select.appendChild(option);
+    });
+  } catch (err) {
+    console.error('Error fetching categories:', err);
+  }
+}
+
+// タグ一覧を取得して<select>要素に追加
+async function loadTagOptions(select) {
+  if (!select) return;
+  try {
+    const options = await fetchMetadataOptions();
+    const list = Array.isArray(options.tags) ? options.tags : [];
+    select.innerHTML = '<option value="">All</option>';
+    list.forEach(name => {
+      const option = document.createElement('option');
+      option.value = name;
+      option.textContent = name;
+      select.appendChild(option);
+    });
+  } catch (err) {
+    console.error('Error fetching tags:', err);
+  }
+}
+
 // DOM が読み込まれた後にページごとの処理を実行します
 // index.html ではファイル一覧を読み込みます
 // ファイル一覧を取得してリストに表示する
@@ -46,10 +107,16 @@ function loadFileList(listElement) {
 }
 
 // フォルダごとにサムネイルをまとめて表示する
-function loadFileListByFolder(container) {
+function loadFileListByFolder(container, options = {}) {
   if (!container) return;
 
-  const url = `https://${API_HOST}/filmaapi/storage?api_key=${encodeURIComponent(API_KEY)}${USE_SHOW_ALL ? "&show_all=true" : ""}`;
+  const params = new URLSearchParams();
+  params.set('api_key', API_KEY);
+  if (USE_SHOW_ALL) params.set('show_all', 'true');
+  if (options.category) params.set('category', options.category);
+  if (options.tag) params.append('tags', options.tag);
+
+  const url = `https://${API_HOST}/filmaapi/storage?${params.toString()}`;
   fetch(url)
     .then(res => {
       if (!res.ok) {
@@ -98,7 +165,14 @@ function loadFileListByFolder(container) {
 
           const caption = document.createElement('div');
           caption.className = 'small text-center text-break mt-1';
-          caption.textContent = file.filename;
+          const meta = [];
+          if (file.user_metadata && file.user_metadata.category) {
+            meta.push(file.user_metadata.category);
+          }
+          if (file.user_metadata && Array.isArray(file.user_metadata.tags)) {
+            meta.push(...file.user_metadata.tags);
+          }
+          caption.innerHTML = `${file.filename}<br><span class="text-muted">${meta.join(', ')}</span>`;
 
           link.classList.add('d-block', 'text-decoration-none');
           link.appendChild(img);
@@ -195,7 +269,9 @@ function buildMetadataHtml(data) {
     ['Created', data.created_at],
     ['Updated', data.updated_at],
     ['Creator', data.creator],
-    ['Updater', data.updater]
+    ['Updater', data.updater],
+    ['Category', data.user_metadata && data.user_metadata.category],
+    ['Tags', Array.isArray(data.user_metadata && data.user_metadata.tags) ? data.user_metadata.tags.join(', ') : null]
   ];
 
   // HTML を組み立てていく


### PR DESCRIPTION
## Summary
- fetch tags and categories from `/filmaapi/storage/metadata_options`
- update sample to populate dropdowns using metadata_keys

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688874c692e48320be232887bc582b38