### PR TITLE
docs.filma.biz のトップに開発者向けLPを設定（Pages workflow対応）

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,9 @@ on:
       - 'api-spec/**'
       - 'template-jwt/**'
       - 'template-no-auth/**'
+      - 'index.html'
+      - 'lp/**'
+      - 'CNAME'
       - '*.md'
       - '_config.yml'
       - '.github/workflows/pages.yml'
@@ -18,6 +21,9 @@ on:
       - 'api-spec/**'
       - 'template-jwt/**'
       - 'template-no-auth/**'
+      - 'index.html'
+      - 'lp/**'
+      - 'CNAME'
       - '*.md'
       - '_config.yml'
       - '.github/workflows/pages.yml'
@@ -85,11 +91,23 @@ jobs:
             cp -f _config.yml publish/_config.yml
           fi
 
-          if [ -f README.md ]; then
-            cp -f README.md publish/index.md
+          # Custom domain: kept in the repo so keep_files:false does not drop it.
+          if [ -f CNAME ]; then
+            cp -f CNAME publish/CNAME
+          fi
+
+          # Top page (https://docs.filma.biz/) is the developer landing page.
+          # README.md is intentionally NOT published; it stays as the repo description.
+          if [ -f index.html ]; then
+            cp -f index.html publish/index.html
           else
-            echo "README.md is required for the GitHub Pages top page." >&2
+            echo "index.html is required for the GitHub Pages top page." >&2
             exit 1
+          fi
+
+          # Landing page assets (absolute /lp/... paths in index.html rely on this).
+          if [ -d lp ]; then
+            cp -a lp publish/lp
           fi
 
           find . -maxdepth 1 -type f -name '*.md' \
@@ -117,5 +135,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./publish
           publish_branch: gh-pages
-          keep_files: true
+          keep_files: false
           enable_jekyll: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /api-spec/site/
 /publish/
 
+# Local Pages preview output (scripts/preview-pages)
+/.preview/
+
 # Generated API spec MkDocs config
 /api-spec/mkdocs.generated.yml
 

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.filma.biz

--- a/index.html
+++ b/index.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filma for Developers | コピペで動く、DRM付き動画配信API</title>
+  <meta name="description" content="Filmaは開発者向けの動画配信PaaS。アップロードするだけでエンコード・マルチDRM暗号化が自動完了。サンプルコードをコピペするだけで、DRM付き動画配信サイトを構築できます。">
+  <meta property="og:title" content="Filma for Developers | コピペで動く、DRM付き動画配信API">
+  <meta property="og:description" content="アップロードするだけでエンコード・マルチDRM暗号化が自動完了。サンプルコードをコピペするだけで動画配信サイトを構築できます。">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://docs.filma.biz/">
+  <!-- 計測タグはここに挿入 (未導入) -->
+  <link rel="stylesheet" href="/lp/assets/lp-common.css">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="container">
+    <a class="brand" href="/">Filma<span>.</span></a>
+    <nav class="global-nav">
+      <a href="#features">機能</a>
+      <a href="#samples">サンプル</a>
+      <a href="#pricing">料金</a>
+      <a href="#faq">FAQ</a>
+      <a class="btn btn-primary btn-small" href="#contact">導入のご相談</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container">
+      <h1>コピペで動く、<br>DRM付き動画配信API。</h1>
+      <p class="lead">Filmaは開発者向けの動画配信PaaSです。アップロードするだけでエンコードとマルチDRM暗号化が自動で完了。あとはサンプルコードをコピペするだけで、動画配信サイトが動き出します。</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#contact">導入のご相談(無料)</a>
+        <a class="btn btn-ghost" href="https://docs.filma.biz/api-spec/">APIリファレンスを見る</a>
+      </div>
+      <p class="hero-note">ご試用・開発期間中は半年まで完全無料。契約前にAPIとサンプルコードをお試しいただけます。</p>
+    </div>
+  </section>
+
+  <!-- コードスニペット -->
+  <section class="section">
+    <div class="container">
+      <h2 class="section-title">埋め込みは、これだけ。</h2>
+      <p class="section-lead">エンコード形式もDRMライセンスも意識する必要はありません。発行されたコードをサイトに貼り付ければ、すぐに再生が始まります。</p>
+      <div class="code-panel">
+        <div class="code-panel-title">index.html — 動画プレイヤーの埋め込み例</div>
+        <pre><span class="comment">&lt;!-- 動画コンテナを置いて --&gt;</span>
+<span class="tag">&lt;div</span> <span class="attr">class</span>=<span class="str">"video-container"</span> <span class="attr">data-media-id</span>=<span class="str">"YOUR_MEDIA_ID"</span><span class="tag">&gt;&lt;/div&gt;</span>
+
+<span class="comment">&lt;!-- プレイヤースクリプトを読み込むだけ --&gt;</span>
+<span class="tag">&lt;script</span> <span class="attr">src</span>=<span class="str">"https://filma.biz/player.js"</span>
+        <span class="attr">data-api-key</span>=<span class="str">"YOUR_API_KEY"</span><span class="tag">&gt;&lt;/script&gt;</span></pre>
+      </div>
+      <p class="hero-note" style="text-align:center">※ 実際のコードは<a href="https://docs.filma.biz/template-no-auth/">サンプル</a>と<a href="https://docs.filma.biz/api-spec/">APIリファレンス</a>をご確認ください。</p>
+    </div>
+  </section>
+
+  <!-- 課題 -->
+  <section class="section section-alt">
+    <div class="container">
+      <h2 class="section-title">動画配信の「面倒」を、すべて肩代わり</h2>
+      <p class="section-lead">動画配信機能を自前で作ろうとすると、本質でない作業に時間が溶けていきます。</p>
+      <div class="card-grid">
+        <div class="card">
+          <span class="card-icon">🎞️</span>
+          <h3>エンコードパイプラインが重い</h3>
+          <p>解像度別の変換、アダプティブ配信対応、ジョブ管理…。FilmaならアップロードだけでMPEG-DASH配信用の変換が全自動で完了します。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🔐</span>
+          <h3>DRMの実装が難しすぎる</h3>
+          <p>Widevine・PlayReady・FairPlayの3方式に標準対応。ライセンスサーバの構築も鍵管理も不要。DRMの知識ゼロで暗号化配信ができます。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">💸</span>
+          <h3>CDN・転送コストが読めない</h3>
+          <p>大手クラウドやCDNを経由しない自社インフラで、転送量込みの定額プラン。予算計画が立てやすい料金体系です。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 機能 -->
+  <section class="section" id="features">
+    <div class="container">
+      <h2 class="section-title">開発者のための機能</h2>
+      <div class="card-grid">
+        <div class="card">
+          <span class="card-icon">⚡</span>
+          <h3>アダプティブストリーミング</h3>
+          <p>MPEG-DASHにより視聴者の回線状況に応じて最適画質を自動選択。Windows / Mac / iOS / Android / Chrome OSで再生できます。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🛡️</span>
+          <h3>マルチDRM標準対応</h3>
+          <p>アップロードするだけで自動暗号化。不正コピー・ダウンロードを防ぎ、プレミアムコンテンツを保護します。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🔑</span>
+          <h3>JWT認証・署名付きURL</h3>
+          <p>会員だけに再生を許可する認可制御をAPIで実装できます。既存の会員基盤との連携も可能です。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🧩</span>
+          <h3>REST API</h3>
+          <p>動画管理(Storage API)、再生(Player / DASH / HLS API)、会員・視聴権管理(Customers / Entitlements API)まで一通り揃っています。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">📦</span>
+          <h3>大容量ストレージ</h3>
+          <p>数ペタバイト級のストレージと専用高速回線。大量の動画アセットも安心して預けられます。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">📝</span>
+          <h3>コピペで始められる</h3>
+          <p>認証なし・JWT認証ありの2種類のサンプルコードを公開中。ウェブ制作ができれば、プログラマがいなくても構築できます。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 導入の流れ -->
+  <section class="section section-alt">
+    <div class="container">
+      <h2 class="section-title">導入は3ステップ</h2>
+      <div class="steps">
+        <div class="step">
+          <h3>動画をアップロード</h3>
+          <p>ウェブ管理画面から動画ファイルをアップロードします。</p>
+        </div>
+        <div class="step">
+          <h3>自動処理を待つ</h3>
+          <p>エンコードとDRM暗号化はすべて自動で完了します。やることはありません。</p>
+        </div>
+        <div class="step">
+          <h3>コードを埋め込む</h3>
+          <p>APIキーを使ってHTML/JavaScriptコードをサイトに貼り付ければ、すぐに再生できます。</p>
+        </div>
+      </div>
+      <div style="margin-top: 40px" class="badge-row">
+        <span class="badge">MPEG-DASH</span>
+        <span class="badge">Widevine</span>
+        <span class="badge">PlayReady</span>
+        <span class="badge">FairPlay</span>
+        <span class="badge">JWT</span>
+        <span class="badge">REST API</span>
+        <span class="badge">HLS</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- サンプル・ドキュメント -->
+  <section class="section" id="samples">
+    <div class="container">
+      <h2 class="section-title">契約前に、コードで確かめる</h2>
+      <p class="section-lead">「触ってから決めたい」に応えるため、APIリファレンスとサンプルコードを公開しています。</p>
+      <div class="card-grid">
+        <a class="card" href="https://docs.filma.biz/template-no-auth/">
+          <span class="card-icon">▶️</span>
+          <h3>認証無し動画サンプル</h3>
+          <p>誰でも見られる動画再生の最小構成サンプル。まずはここから。</p>
+        </a>
+        <a class="card" href="https://docs.filma.biz/template-jwt/">
+          <span class="card-icon">🎫</span>
+          <h3>JWT認証付きサンプル</h3>
+          <p>会員制配信を想定した、JWTによる再生認可のサンプルです。</p>
+        </a>
+        <a class="card" href="https://docs.filma.biz/api-spec/">
+          <span class="card-icon">📚</span>
+          <h3>APIリファレンス</h3>
+          <p>認証、エンドポイント、使用例まで。詳細なAPI仕様を公開しています。</p>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- 実績 -->
+  <section class="section section-alt">
+    <div class="container">
+      <h2 class="section-title">実績あるインフラの上に</h2>
+      <div class="stats">
+        <div class="stat">
+          <div class="stat-value">20年</div>
+          <div class="stat-label">プレミアムコンテンツ配信の運用実績</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">数十億円</div>
+          <div class="stat-label">相当のコンテンツを安定配信</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">数PB級</div>
+          <div class="stat-label">の大容量ストレージと専用高速回線</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 料金 -->
+  <section class="section" id="pricing">
+    <div class="container">
+      <h2 class="section-title">シンプルな料金</h2>
+      <p class="section-lead">自社配信システムにより、転送量込みで競争力のある価格を実現しています。</p>
+      <div class="pricing-scroll">
+        <table class="pricing-table">
+          <thead>
+            <tr>
+              <th>プラン</th>
+              <th>年額</th>
+              <th>転送量</th>
+              <th>保存容量</th>
+              <th>機能</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Standard</strong></td>
+              <td class="price">¥498,000</td>
+              <td>10TB</td>
+              <td>10TB</td>
+              <td>DRM非対応 / 無料配信可 / 有料配信可 / 会員制配信可</td>
+            </tr>
+            <tr>
+              <td><strong>Pro</strong></td>
+              <td class="price">¥980,000</td>
+              <td>50TB</td>
+              <td>50TB</td>
+              <td>DRM対応 / 無料配信可 / 有料配信可 / 会員制配信可</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <ul class="pricing-notes">
+        <li>※ ご試用・開発の期間中に限り、半年まで完全無料でご利用いただけます。半年以内でも本番稼働後は有料となります。</li>
+        <li>※ 銀行振込をご希望の方は、年額プラン(先払い・解約不可)でのご契約に限らせていただきます。月額プランをご希望の方は、クレジットカード決済をご利用ください。</li>
+        <li>※ 転送量・保存容量が超過した場合は、別途、追加費用を頂きます。詳細はご相談ください。</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section class="section section-alt" id="faq">
+    <div class="container">
+      <h2 class="section-title">よくあるご質問</h2>
+      <div class="faq-list">
+        <details>
+          <summary>認証・認可はどのように実装しますか?</summary>
+          <p>APIキー認証とJWT認証の2方式に対応しています。会員だけに再生を許可する場合はJWTを利用します。<a href="https://docs.filma.biz/template-jwt/">JWT認証付きサンプル</a>と<a href="https://docs.filma.biz/api-spec/">APIリファレンスの認証の章</a>をご覧ください。</p>
+        </details>
+        <details>
+          <summary>WordPressサイトに埋め込めますか?</summary>
+          <p>可能です。発行される埋め込みコードをWordPressの投稿・固定ページに貼り付けることで再生できます。</p>
+        </details>
+        <details>
+          <summary>海外からの再生はできますか?</summary>
+          <p>再生自体は可能ですが、クラウドや大手CDNを経由しない国内自社インフラのため、海外からの再生は低速になる場合があります。また可用性やデータの完全性は大手クラウド・大手CDNより劣ります。高可用性が必要な場合はご相談ください。</p>
+        </details>
+        <details>
+          <summary>StandardプランからProプランに変更できますか?</summary>
+          <p>アップグレードは可能です。ただしアップロード済み動画にDRMを付与する場合は再エンコードが必要で、動画ファイル数が多い場合は時間がかかります。ProからStandardへのダウングレードは、DRM付き動画が視聴不能になるため原則不可です。</p>
+        </details>
+        <details>
+          <summary>転送量や保存容量を超過した場合は?</summary>
+          <p>別途追加費用にてご利用いただけます。超過が見込まれる場合は事前にご相談ください。</p>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-band" id="contact">
+    <div class="container">
+      <h2>まずは、触ってみてください。</h2>
+      <p>現在ローンチ直後のため、お申し込みは原則として紹介制とさせていただいております。導入のご相談・機能のご要望は提供会社までお気軽にお問い合わせください。ご試用・開発期間中は半年まで無料です。</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="https://cream.co.jp/">導入のご相談(株式会社クリーム)</a>
+        <a class="btn btn-ghost" href="https://docs.filma.biz/">ドキュメントを見る</a>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer class="site-footer">
+  <div class="container">
+    <div class="footer-columns">
+      <div>
+        <h3>Filma</h3>
+        <ul>
+          <li><a href="https://docs.filma.biz/">ドキュメントトップ</a></li>
+          <li><a href="https://docs.filma.biz/api-spec/">APIリファレンス</a></li>
+          <li><a href="https://docs.filma.biz/admin-manual/">管理画面マニュアル</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>他の用途で探す</h3>
+        <ul>
+          <li><a href="/lp/elearning/">eラーニング・社内研修での利用</a></li>
+          <li><a href="/lp/ip/">IPホルダー・版権元の方へ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>規約・提供会社</h3>
+        <ul>
+          <li><a href="https://docs.filma.biz/terms_of_service_template">ご利用規約</a></li>
+          <li><a href="https://docs.filma.biz/service_level_agreement">サービスレベルアグリーメント</a></li>
+          <li><a href="https://cream.co.jp/">株式会社クリーム</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-copy">Filma — 動画配信プラットフォーム (PaaS) / 提供: 株式会社クリーム</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/lp/assets/lp-common.css
+++ b/lp/assets/lp-common.css
@@ -30,6 +30,12 @@
 
 html { scroll-behavior: smooth; }
 
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+}
+
+section[id] { scroll-margin-top: 84px; }
+
 body {
   margin: 0;
   font-family: var(--font-body);

--- a/lp/assets/lp-common.css
+++ b/lp/assets/lp-common.css
@@ -1,0 +1,520 @@
+/* ==========================================================================
+   Filma LP 共通スタイル
+   3つのLP (developers / elearning / ip) で共有するデザイントークンと
+   セクションコンポーネント。詳細は lp/DESIGN.md を参照。
+   ========================================================================== */
+
+:root {
+  /* カラートークン */
+  --color-bg: #0b1220;
+  --color-bg-raised: #131d33;
+  --color-bg-card: #18233c;
+  --color-border: #2a3752;
+  --color-text: #e6ebf4;
+  --color-text-muted: #9aa7bf;
+  --color-accent: #38bdf8;
+  --color-accent-strong: #0ea5e9;
+  --color-accent-contrast: #06222f;
+  --color-light-section: #f5f7fb;
+  --color-light-text: #1c2434;
+  --color-light-muted: #5b6b80;
+  /* タイポグラフィ */
+  --font-body: system-ui, -apple-system, "Hiragino Sans", "Noto Sans JP", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  /* レイアウト */
+  --content-width: 1080px;
+  --section-pad: 72px;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: var(--color-bg);
+  line-height: 1.8;
+}
+
+img { max-width: 100%; height: auto; }
+
+a { color: var(--color-accent); }
+
+.container {
+  max-width: var(--content-width);
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+/* --- ヘッダー ----------------------------------------------------------- */
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(11, 18, 32, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  height: 64px;
+}
+
+.brand {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--color-text);
+  text-decoration: none;
+  letter-spacing: 0.04em;
+}
+
+.brand span { color: var(--color-accent); }
+
+.global-nav {
+  display: flex;
+  gap: 20px;
+  margin-left: auto;
+  align-items: center;
+}
+
+.global-nav a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-size: 14px;
+}
+
+.global-nav a:hover { color: var(--color-text); }
+
+/* ナビ内に置いたボタンは .global-nav a の文字色より優先させる */
+.global-nav a.btn-primary,
+.global-nav a.btn-primary:hover {
+  color: var(--color-accent-contrast);
+}
+
+/* --- ボタン ------------------------------------------------------------- */
+
+.btn {
+  display: inline-block;
+  padding: 12px 28px;
+  border-radius: 8px;
+  font-weight: 700;
+  font-size: 15px;
+  text-decoration: none;
+  transition: opacity 0.15s ease;
+}
+
+.btn:hover { opacity: 0.85; }
+
+.btn-primary {
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
+}
+
+.btn-ghost {
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.btn-small { padding: 8px 18px; font-size: 13px; }
+
+/* --- Hero --------------------------------------------------------------- */
+
+.hero {
+  padding: 96px 0 72px;
+  background:
+    radial-gradient(ellipse 60% 50% at 70% 0%, rgba(56, 189, 248, 0.16), transparent),
+    var(--color-bg);
+  text-align: center;
+}
+
+.hero h1 {
+  font-size: 42px;
+  line-height: 1.4;
+  margin: 0 0 16px;
+  letter-spacing: 0.02em;
+}
+
+.hero .lead {
+  font-size: 17px;
+  color: var(--color-text-muted);
+  max-width: 640px;
+  margin: 0 auto 32px;
+}
+
+.hero-cta {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.hero-note {
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+/* --- セクション共通 ------------------------------------------------------ */
+
+.section { padding: var(--section-pad) 0; }
+
+.section-title {
+  text-align: center;
+  font-size: 30px;
+  margin: 0 0 12px;
+}
+
+.section-lead {
+  text-align: center;
+  color: var(--color-text-muted);
+  max-width: 640px;
+  margin: 0 auto 48px;
+}
+
+.section-alt { background: var(--color-bg-raised); }
+
+/* --- カードグリッド ------------------------------------------------------ */
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+.card {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 28px 24px;
+}
+
+.card h3 {
+  margin: 0 0 8px;
+  font-size: 17px;
+}
+
+.card p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-text-muted);
+}
+
+.card .card-icon {
+  font-size: 26px;
+  margin-bottom: 12px;
+  display: block;
+}
+
+a.card {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s ease;
+}
+
+a.card:hover { border-color: var(--color-accent); }
+
+/* --- コードブロック ------------------------------------------------------ */
+
+.code-panel {
+  background: #0a0f1c;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  overflow: hidden;
+  max-width: 760px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.code-panel-title {
+  padding: 10px 16px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.code-panel pre {
+  margin: 0;
+  padding: 20px;
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.7;
+  color: #c9d6ea;
+}
+
+.code-panel .tag { color: #7dd3fc; }
+.code-panel .attr { color: #a5b4fc; }
+.code-panel .str { color: #86efac; }
+.code-panel .comment { color: #64748b; }
+
+/* --- ステップ ------------------------------------------------------------ */
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  counter-reset: step;
+}
+
+.step {
+  position: relative;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  padding: 28px 24px;
+}
+
+.step::before {
+  counter-increment: step;
+  content: counter(step);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--color-accent);
+  color: var(--color-accent-contrast);
+  font-weight: 700;
+  margin-bottom: 14px;
+}
+
+.step h3 { margin: 0 0 8px; font-size: 16px; }
+.step p { margin: 0; font-size: 14px; color: var(--color-text-muted); }
+
+/* --- バッジ列 ------------------------------------------------------------ */
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}
+
+.badge {
+  padding: 6px 16px;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+}
+
+/* --- 実績 ---------------------------------------------------------------- */
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+  text-align: center;
+}
+
+.stat .stat-value {
+  font-size: 38px;
+  font-weight: 700;
+  color: var(--color-accent);
+  line-height: 1.2;
+}
+
+.stat .stat-label {
+  font-size: 14px;
+  color: var(--color-text-muted);
+  margin-top: 6px;
+}
+
+/* --- 料金テーブル --------------------------------------------------------- */
+
+.pricing-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  overflow: hidden;
+  font-size: 14px;
+}
+
+.pricing-table th,
+.pricing-table td {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+}
+
+.pricing-table thead th {
+  background: var(--color-bg-raised);
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.pricing-table .price {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--color-accent);
+}
+
+.pricing-notes {
+  margin-top: 20px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+}
+
+.pricing-notes li { margin-bottom: 4px; }
+
+/* --- FAQ ------------------------------------------------------------------ */
+
+.faq-list {
+  max-width: 760px;
+  margin: 0 auto;
+}
+
+.faq-list details {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  margin-bottom: 12px;
+  padding: 0 20px;
+}
+
+.faq-list summary {
+  cursor: pointer;
+  padding: 16px 0;
+  font-weight: 700;
+  font-size: 15px;
+  list-style: none;
+  position: relative;
+  padding-right: 28px;
+}
+
+.faq-list summary::-webkit-details-marker { display: none; }
+
+.faq-list summary::after {
+  content: "+";
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--color-accent);
+  font-size: 20px;
+}
+
+.faq-list details[open] summary::after { content: "−"; }
+
+.faq-list details p {
+  margin: 0 0 16px;
+  font-size: 14px;
+  color: var(--color-text-muted);
+}
+
+/* --- CTAバンド ------------------------------------------------------------ */
+
+.cta-band {
+  text-align: center;
+  padding: 72px 0;
+  background:
+    radial-gradient(ellipse 50% 80% at 50% 100%, rgba(56, 189, 248, 0.14), transparent),
+    var(--color-bg-raised);
+}
+
+.cta-band h2 { font-size: 28px; margin: 0 0 12px; }
+
+.cta-band p {
+  color: var(--color-text-muted);
+  max-width: 560px;
+  margin: 0 auto 28px;
+}
+
+/* --- フッター -------------------------------------------------------------- */
+
+.site-footer {
+  border-top: 1px solid var(--color-border);
+  padding: 48px 0 32px;
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.footer-columns {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  margin-bottom: 32px;
+}
+
+.footer-columns h3 {
+  font-size: 13px;
+  color: var(--color-text);
+  margin: 0 0 10px;
+}
+
+.footer-columns ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.footer-columns li { margin-bottom: 6px; }
+
+.footer-columns a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
+.footer-columns a:hover { color: var(--color-text); }
+
+.footer-copy {
+  text-align: center;
+  border-top: 1px solid var(--color-border);
+  padding-top: 24px;
+}
+
+/* --- 比較テーブル(eラーニングLP用) ---------------------------------------- */
+
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+}
+
+.compare-table th,
+.compare-table td {
+  padding: 12px 16px;
+  border: 1px solid var(--color-border);
+  text-align: center;
+}
+
+.compare-table td:first-child,
+.compare-table th:first-child { text-align: left; }
+
+.compare-table .good { color: #4ade80; font-weight: 700; }
+.compare-table .bad { color: #f87171; }
+
+/* --- レスポンシブ ----------------------------------------------------------- */
+
+@media (max-width: 768px) {
+  :root { --section-pad: 48px; }
+
+  .hero { padding: 64px 0 48px; }
+  .hero h1 { font-size: 28px; }
+  .section-title { font-size: 24px; }
+
+  .card-grid,
+  .steps,
+  .stats,
+  .footer-columns {
+    grid-template-columns: 1fr;
+  }
+
+  .global-nav a:not(.btn) { display: none; }
+
+  .pricing-scroll { overflow-x: auto; }
+  .pricing-table { min-width: 560px; }
+}

--- a/lp/assets/theme-elearning.css
+++ b/lp/assets/theme-elearning.css
@@ -1,0 +1,45 @@
+/* ==========================================================================
+   eラーニング事業者向けLP テーマ
+   lp-common.css の後に読み込む。明るく親しみやすいライトテーマ(グリーン)。
+   非技術者向けのため、堅さより「わかりやすさ・安心感」を優先する。
+   ========================================================================== */
+
+:root {
+  --color-bg: #f7faf9;
+  --color-bg-raised: #ecf4f0;
+  --color-bg-card: #ffffff;
+  --color-border: #d9e5df;
+  --color-text: #22303c;
+  --color-text-muted: #5c6f70;
+  --color-accent: #0e9f6e;
+  --color-accent-strong: #057a55;
+  --color-accent-contrast: #ffffff;
+}
+
+.site-header {
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.hero {
+  background:
+    radial-gradient(ellipse 60% 50% at 70% 0%, rgba(14, 159, 110, 0.12), transparent),
+    var(--color-bg);
+}
+
+.card,
+.step {
+  box-shadow: 0 1px 3px rgba(20, 45, 35, 0.06);
+}
+
+.badge {
+  background: #ffffff;
+}
+
+.cta-band {
+  background:
+    radial-gradient(ellipse 50% 80% at 50% 100%, rgba(14, 159, 110, 0.12), transparent),
+    var(--color-bg-raised);
+}
+
+.compare-table .good { color: var(--color-accent-strong); }
+.compare-table .bad { color: #d93025; }

--- a/lp/assets/theme-ip.css
+++ b/lp/assets/theme-ip.css
@@ -1,0 +1,43 @@
+/* ==========================================================================
+   IPホルダー向けLP テーマ
+   lp-common.css の後に読み込む。重厚・プレミアム感のあるダーク×ゴールド。
+   見出しに明朝体を使い、保護と信頼を印象付ける。
+   ========================================================================== */
+
+:root {
+  --color-bg: #0e0b13;
+  --color-bg-raised: #171221;
+  --color-bg-card: #1c1628;
+  --color-border: #362c49;
+  --color-text: #ece7dd;
+  --color-text-muted: #a9a093;
+  --color-accent: #d8b45a;
+  --color-accent-strong: #c9a227;
+  --color-accent-contrast: #241b06;
+}
+
+.brand,
+.hero h1,
+.section-title,
+.cta-band h2 {
+  font-family: "Hiragino Mincho ProN", "Yu Mincho", "Noto Serif JP", serif;
+  letter-spacing: 0.06em;
+}
+
+.site-header {
+  background: rgba(14, 11, 19, 0.92);
+}
+
+.hero {
+  background:
+    radial-gradient(ellipse 60% 50% at 70% 0%, rgba(216, 180, 90, 0.13), transparent),
+    var(--color-bg);
+}
+
+.hero h1 { font-weight: 600; }
+
+.cta-band {
+  background:
+    radial-gradient(ellipse 50% 80% at 50% 100%, rgba(216, 180, 90, 0.12), transparent),
+    var(--color-bg-raised);
+}

--- a/lp/elearning/index.html
+++ b/lp/elearning/index.html
@@ -17,7 +17,7 @@
 
 <header class="site-header">
   <div class="container">
-    <a class="brand" href="/lp/elearning/">Filma<span>.</span></a>
+    <a class="brand" href="/">Filma<span>.</span></a>
     <nav class="global-nav">
       <a href="#features">できること</a>
       <a href="#compare">YouTubeとの違い</a>

--- a/lp/elearning/index.html
+++ b/lp/elearning/index.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filma for eLearning | セミナー動画を、社員・会員だけに。安全に、低コストで。</title>
+  <meta name="description" content="社内研修・セミナーアーカイブ・有料講座の動画を、受講者だけに配信。コピーガードで録画・ダウンロードによる流出を防ぎながら、管理画面だけで運用できます。プログラマは必要ありません。">
+  <meta property="og:title" content="Filma for eLearning | セミナー動画を、社員・会員だけに。">
+  <meta property="og:description" content="研修・講座の動画を受講者だけに配信。コピーガードで流出を防ぎながら、管理画面だけで運用できます。">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://docs.filma.biz/lp/elearning/">
+  <!-- 計測タグはここに挿入 (未導入) -->
+  <link rel="stylesheet" href="/lp/assets/lp-common.css">
+  <link rel="stylesheet" href="/lp/assets/theme-elearning.css">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="container">
+    <a class="brand" href="/lp/elearning/">Filma<span>.</span></a>
+    <nav class="global-nav">
+      <a href="#features">できること</a>
+      <a href="#compare">YouTubeとの違い</a>
+      <a href="#pricing">料金</a>
+      <a href="#faq">FAQ</a>
+      <a class="btn btn-primary btn-small" href="#contact">導入のご相談</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container">
+      <h1>セミナー動画を、社員・会員だけに。<br>安全に、低コストで。</h1>
+      <p class="lead">社内研修・セミナーアーカイブ・有料講座の動画を、見せたい人にだけ配信。コピーガードで録画やダウンロードによる流出を防ぎながら、ふだんの管理画面操作だけで運用できます。プログラマは必要ありません。</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#contact">導入のご相談(無料)</a>
+        <a class="btn btn-ghost" href="#compare">YouTube限定公開との違い</a>
+      </div>
+      <p class="hero-note">ご試用の期間中は半年まで完全無料。じっくり試してから決められます。</p>
+    </div>
+  </section>
+
+  <!-- 課題 -->
+  <section class="section section-alt">
+    <div class="container">
+      <h2 class="section-title">研修・講座の動画配信、こんなお悩みはありませんか?</h2>
+      <div class="card-grid">
+        <div class="card">
+          <span class="card-icon">😰</span>
+          <h3>コンテンツの流出が怖い</h3>
+          <p>時間とコストをかけて作った研修動画や講座が、録画・ダウンロードされて出回ってしまったら…。教材はビジネスの資産です。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🔗</span>
+          <h3>URLの共有で見られてしまう</h3>
+          <p>「限定公開」のつもりでも、URLが転送されれば誰でも見られる状態に。受講料を払った人だけに届けたいのに、線引きができない。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🧑‍💻</span>
+          <h3>社内に技術者がいない</h3>
+          <p>配信システムを作るには専門知識が必要そう…。外注すると高額になりそうで、最初の一歩が踏み出せない。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- できること -->
+  <section class="section" id="features">
+    <div class="container">
+      <h2 class="section-title">Filmaなら、ぜんぶ解決できます</h2>
+      <p class="section-lead">動画配信の難しいところはFilmaが引き受けます。あなたはコンテンツづくりに集中してください。</p>
+      <div class="card-grid">
+        <div class="card">
+          <span class="card-icon">👥</span>
+          <h3>見せたい人にだけ配信</h3>
+          <p>会員・受講者だけが視聴できる仕組みを標準装備。購入や受講の状況に応じて「誰がどの動画を見られるか」を管理できます。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🔒</span>
+          <h3>コピーガードで流出を防止</h3>
+          <p>動画は自動で暗号化され、不正なコピーやダウンロードを防ぎます。大切な教材を守る、大手動画配信サービスと同じ仕組みの保護技術です。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">📶</span>
+          <h3>途切れにくい、きれいな再生</h3>
+          <p>視聴者の通信環境に合わせて画質を自動調整。スマホでもパソコンでも、ストレスなく受講してもらえます。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🖱️</span>
+          <h3>管理画面だけで完結</h3>
+          <p>動画のアップロードから公開まで、ウェブの管理画面で操作できます。配信の準備(変換・保護)はすべて自動です。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">📝</span>
+          <h3>自社サイトにそのまま設置</h3>
+          <p>発行されるコードを貼り付けるだけで、自社サイトやWordPressに動画を設置できます。ウェブ制作会社への依頼もスムーズです。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">💰</span>
+          <h3>定額でコストが読める</h3>
+          <p>視聴が増えても慌てない、転送量込みの年額プラン。独自インフラによる低コスト配信で、教材ビジネスの利益を守ります。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 比較 -->
+  <section class="section section-alt" id="compare">
+    <div class="container">
+      <h2 class="section-title">YouTube限定公開との違い</h2>
+      <p class="section-lead">手軽さで選ばれがちなYouTubeの限定公開ですが、「ビジネスとしての教材配信」には不向きな点があります。</p>
+      <table class="compare-table">
+        <thead>
+          <tr>
+            <th></th>
+            <th>YouTube限定公開</th>
+            <th>Filma</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>視聴できる人の限定</td>
+            <td class="bad">URLを知っていれば誰でも視聴可能</td>
+            <td class="good">会員・受講者だけに限定できる</td>
+          </tr>
+          <tr>
+            <td>流出への対策</td>
+            <td class="bad">URLの転送・拡散を止められない</td>
+            <td class="good">コピーガードで録画・ダウンロードを防止</td>
+          </tr>
+          <tr>
+            <td>広告・おすすめ動画</td>
+            <td class="bad">他社の動画や広告へ誘導されることがある</td>
+            <td class="good">表示なし。自社サイトの中で完結</td>
+          </tr>
+          <tr>
+            <td>有料販売</td>
+            <td class="bad">規約上の制約があり自由に設計しにくい</td>
+            <td class="good">有料配信・会員制配信に標準対応</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ユースケース -->
+  <section class="section">
+    <div class="container">
+      <h2 class="section-title">こんな使い方をされています</h2>
+      <div class="card-grid">
+        <div class="card">
+          <span class="card-icon">🏢</span>
+          <h3>社内研修・セミナーアーカイブ</h3>
+          <p>過去のセミナーや研修を録画して社員・会員向けにアーカイブ配信。「あの回をもう一度見たい」に応えます。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🎓</span>
+          <h3>有料オンライン講座・スクール</h3>
+          <p>受講料を払った人だけが視聴できるオンライン講座。コピーガードで教材の価値を守りながら販売できます。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🤝</span>
+          <h3>会員制サロン・コミュニティ</h3>
+          <p>会員限定の動画コンテンツで、コミュニティの継続率と満足度を高めます。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 導入の流れ -->
+  <section class="section section-alt">
+    <div class="container">
+      <h2 class="section-title">はじめかたは、かんたん3ステップ</h2>
+      <div class="steps">
+        <div class="step">
+          <h3>動画をアップロード</h3>
+          <p>ウェブの管理画面から、お手持ちの動画ファイルをアップロードします。</p>
+        </div>
+        <div class="step">
+          <h3>あとは待つだけ</h3>
+          <p>配信用の変換もコピーガードも、すべて自動で完了します。専門知識は不要です。</p>
+        </div>
+        <div class="step">
+          <h3>サイトに貼り付け</h3>
+          <p>発行されたコードを自社サイトやWordPressに貼り付ければ、配信スタートです。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 実績 -->
+  <section class="section">
+    <div class="container">
+      <h2 class="section-title">安心して預けられる配信基盤</h2>
+      <div class="stats">
+        <div class="stat">
+          <div class="stat-value">20年</div>
+          <div class="stat-label">の動画配信 運用実績</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">数十億円</div>
+          <div class="stat-label">相当の有料コンテンツを安定配信</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">完全国産</div>
+          <div class="stat-label">自社インフラ・日本語サポート</div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 料金 -->
+  <section class="section section-alt" id="pricing">
+    <div class="container">
+      <h2 class="section-title">わかりやすい料金</h2>
+      <p class="section-lead">転送量込みの年額プラン。視聴者が増えても料金が急に跳ね上がる心配はありません。</p>
+      <div class="pricing-scroll">
+        <table class="pricing-table">
+          <thead>
+            <tr>
+              <th>プラン</th>
+              <th>年額</th>
+              <th>転送量</th>
+              <th>保存容量</th>
+              <th>機能</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Standard</strong></td>
+              <td class="price">¥498,000</td>
+              <td>10TB</td>
+              <td>10TB</td>
+              <td>コピーガードなし / 無料配信可 / 有料配信可 / 会員制配信可</td>
+            </tr>
+            <tr>
+              <td><strong>Pro</strong></td>
+              <td class="price">¥980,000</td>
+              <td>50TB</td>
+              <td>50TB</td>
+              <td>コピーガード対応 / 無料配信可 / 有料配信可 / 会員制配信可</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <ul class="pricing-notes">
+        <li>※ 教材の流出対策(コピーガード)が必要な場合は、Proプランをお選びください。</li>
+        <li>※ ご試用の期間中に限り、半年まで完全無料でご利用いただけます。半年以内でも本番稼働後は有料となります。</li>
+        <li>※ 銀行振込をご希望の方は、年額プラン(先払い・解約不可)でのご契約に限らせていただきます。月額プランをご希望の方は、クレジットカード決済をご利用ください。</li>
+        <li>※ 転送量・保存容量が超過した場合は、別途、追加費用を頂きます。詳細はご相談ください。</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section class="section" id="faq">
+    <div class="container">
+      <h2 class="section-title">よくあるご質問</h2>
+      <div class="faq-list">
+        <details>
+          <summary>受講者ごとに、見られる動画を分けられますか?</summary>
+          <p>できます。会員と視聴権限を管理する仕組みがあり、「この講座を購入した人にはこの動画」というように、視聴できる範囲をコントロールできます。</p>
+        </details>
+        <details>
+          <summary>社内に技術者がいなくても運用できますか?</summary>
+          <p>できます。日々の運用(アップロード・公開・会員管理)はウェブの管理画面で完結します。自社サイトへの設置は発行されたコードを貼り付けるだけなので、ふだんお付き合いのあるウェブ制作会社に依頼することもできます。</p>
+        </details>
+        <details>
+          <summary>あとからコピーガードを付けることはできますか?</summary>
+          <p>StandardプランからProプランへのアップグレードで可能です。ただし、アップロード済みの動画にコピーガードを付ける際は変換作業のやり直しが必要で、動画の本数が多い場合はお時間をいただきます。流出対策が必要とわかっている場合は、最初からProプランをおすすめします。</p>
+        </details>
+        <details>
+          <summary>海外にいる受講者も視聴できますか?</summary>
+          <p>視聴自体は可能ですが、国内の自社設備から配信しているため、海外からの再生は速度が遅くなる場合があります。海外の受講者が多い場合は、事前にご相談ください。</p>
+        </details>
+        <details>
+          <summary>YouTubeの「限定公開」と何が違うのですか?</summary>
+          <p>限定公開はURLを知っていれば誰でも見られてしまい、転送・拡散を止められません。Filmaは会員・受講者だけに視聴を限定でき、さらにコピーガードで録画・ダウンロードによる流出も防げます。詳しくは<a href="#compare">比較表</a>をご覧ください。</p>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-band" id="contact">
+    <div class="container">
+      <h2>まずは、お気軽にご相談ください。</h2>
+      <p>現在ローンチ直後のため、お申し込みは原則として紹介制とさせていただいております。「うちの使い方でもできる?」といったご質問だけでも歓迎です。ご試用の期間中は半年まで無料です。</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="https://cream.co.jp/">導入のご相談(株式会社クリーム)</a>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer class="site-footer">
+  <div class="container">
+    <div class="footer-columns">
+      <div>
+        <h3>Filma</h3>
+        <ul>
+          <li><a href="https://docs.filma.biz/">サービス紹介・ドキュメント</a></li>
+          <li><a href="https://docs.filma.biz/admin-manual/">管理画面マニュアル</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>他の用途で探す</h3>
+        <ul>
+          <li><a href="/">開発者・開発会社の方へ</a></li>
+          <li><a href="/lp/ip/">IPホルダー・版権元の方へ</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>規約・提供会社</h3>
+        <ul>
+          <li><a href="https://docs.filma.biz/terms_of_service_template">ご利用規約</a></li>
+          <li><a href="https://docs.filma.biz/service_level_agreement">サービスレベルアグリーメント</a></li>
+          <li><a href="https://cream.co.jp/">株式会社クリーム</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-copy">Filma — 動画配信プラットフォーム / 提供: 株式会社クリーム</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/lp/ip/index.html
+++ b/lp/ip/index.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filma for IP Holders | 大切な作品を、守りながら、ファンへ直接。</title>
+  <meta name="description" content="アニメ・映像などのIPホルダー向け動画配信基盤。大手動画配信サービスと同水準のコピーガードで作品を保護しながら、公式配信・ファンクラブ・単品販売を自社で運営できます。20年のプレミアムコンテンツ配信実績。">
+  <meta property="og:title" content="Filma for IP Holders | 大切な作品を、守りながら、ファンへ直接。">
+  <meta property="og:description" content="大手動画配信サービスと同水準のコピーガードで作品を保護しながら、公式配信を自社で運営できます。">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://docs.filma.biz/lp/ip/">
+  <!-- 計測タグはここに挿入 (未導入) -->
+  <link rel="stylesheet" href="/lp/assets/lp-common.css">
+  <link rel="stylesheet" href="/lp/assets/theme-ip.css">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="container">
+    <a class="brand" href="/lp/ip/">Filma<span>.</span></a>
+    <nav class="global-nav">
+      <a href="#protection">保護の仕組み</a>
+      <a href="#business">配信のかたち</a>
+      <a href="#trust">実績</a>
+      <a href="#faq">FAQ</a>
+      <a class="btn btn-primary btn-small" href="#contact">導入のご相談</a>
+    </nav>
+  </div>
+</header>
+
+<main>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container">
+      <h1>大切な作品を、守りながら、<br>ファンへ直接。</h1>
+      <p class="lead">Filmaは、20年にわたり数十億円相当のプレミアムコンテンツを配信してきた、完全国産の動画配信基盤です。大手動画配信サービスと同水準のコピーガードで作品を保護しながら、公式配信・ファンクラブ・単品販売を自社の手で運営できます。</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#contact">導入のご相談(無料)</a>
+        <a class="btn btn-ghost" href="#protection">保護の仕組みを見る</a>
+      </div>
+      <p class="hero-note">お申し込みは現在紹介制です。まずはご相談ください。</p>
+    </div>
+  </section>
+
+  <!-- 課題 -->
+  <section class="section section-alt">
+    <div class="container">
+      <h2 class="section-title">作品を預ける先に、確信を持てていますか</h2>
+      <div class="card-grid">
+        <div class="card">
+          <span class="card-icon">⚠️</span>
+          <h3>不正コピー・流出のリスク</h3>
+          <p>一度流出した映像は回収できません。作品の価値とライセンスビジネスを守るには、配信段階での確かな保護が不可欠です。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🏛️</span>
+          <h3>プラットフォーム依存</h3>
+          <p>大手配信サービスへの出品は、手数料・規約変更・露出のコントロールが利かないという構造的な課題を抱えています。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">💌</span>
+          <h3>ファンに直接届けたい</h3>
+          <p>公式だからこそ出せる映像を、ファンへ直接。しかし配信基盤を自社開発するのは、コストもリスクも大きすぎます。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 保護の仕組み -->
+  <section class="section" id="protection">
+    <div class="container">
+      <h2 class="section-title">作品を守る仕組み</h2>
+      <p class="section-lead">Filmaのコピーガードは、大手動画配信サービスでも採用されている業界標準の保護技術です。専門知識は不要で、アップロードするだけで自動的に適用されます。</p>
+      <div class="steps">
+        <div class="step">
+          <h3>アップロードで自動暗号化</h3>
+          <p>お預かりした映像は自動で暗号化されます。もとのファイルがそのまま配信網に置かれることはありません。</p>
+        </div>
+        <div class="step">
+          <h3>視聴者ごとに再生を許可</h3>
+          <p>許可された視聴者の端末にだけ、再生のための鍵が発行されます。会員・購入者以外は再生できません。</p>
+        </div>
+        <div class="step">
+          <h3>コピー・保存をブロック</h3>
+          <p>不正なコピーやダウンロード保存を防ぎます。パソコン・スマホ・タブレットの主要な環境に対応しています。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 配信のかたち -->
+  <section class="section section-alt" id="business">
+    <div class="container">
+      <h2 class="section-title">公式配信の、あらゆるかたちに</h2>
+      <p class="section-lead">無料の告知映像から、会員限定、有料販売まで。作品と施策に合わせて配信のかたちを選べます。</p>
+      <div class="card-grid">
+        <div class="card">
+          <span class="card-icon">⭐</span>
+          <h3>公式ファンクラブ</h3>
+          <p>会員だけが見られる限定映像で、ファンクラブの価値を高めます。会員管理の仕組みも備えています。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🎬</span>
+          <h3>見放題・アーカイブ配信</h3>
+          <p>過去作品やイベント映像のアーカイブを、月額会員向けに見放題で提供できます。</p>
+        </div>
+        <div class="card">
+          <span class="card-icon">🎟️</span>
+          <h3>単品販売・レンタル</h3>
+          <p>新作や特典映像の単品販売にも対応。価格も販売方法も、自社の方針で自由に設計できます。</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- 実績・信頼 -->
+  <section class="section" id="trust">
+    <div class="container">
+      <h2 class="section-title">20年、作品を預かり続けてきた実績</h2>
+      <p class="section-lead">Filmaは新しいサービスですが、その基盤は20年にわたりプレミアムコンテンツの有料配信を支えてきた自社設備です。</p>
+      <div class="stats">
+        <div class="stat">
+          <div class="stat-value">20年</div>
+          <div class="stat-label">プレミアムコンテンツ配信の運用実績</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">数十億円</div>
+          <div class="stat-label">相当の有料コンテンツを安定配信</div>
+        </div>
+        <div class="stat">
+          <div class="stat-value">完全国産</div>
+          <div class="stat-label">自社設備・日本法準拠・日本語サポート</div>
+        </div>
+      </div>
+      <div style="margin-top: 40px" class="badge-row">
+        <span class="badge">数ペタバイト級の自社ストレージ</span>
+        <span class="badge">専用高速回線</span>
+        <span class="badge">日本法を遵守したコンテンツは原則配信可能</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- 料金 -->
+  <section class="section section-alt" id="pricing">
+    <div class="container">
+      <h2 class="section-title">料金</h2>
+      <p class="section-lead">独自設備による配信で、転送量込みの明快な年額プランを実現しています。</p>
+      <div class="pricing-scroll">
+        <table class="pricing-table">
+          <thead>
+            <tr>
+              <th>プラン</th>
+              <th>年額</th>
+              <th>転送量</th>
+              <th>保存容量</th>
+              <th>機能</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>Standard</strong></td>
+              <td class="price">¥498,000</td>
+              <td>10TB</td>
+              <td>10TB</td>
+              <td>コピーガードなし / 無料配信可 / 有料配信可 / 会員制配信可</td>
+            </tr>
+            <tr>
+              <td><strong>Pro</strong></td>
+              <td class="price">¥980,000</td>
+              <td>50TB</td>
+              <td>50TB</td>
+              <td>コピーガード対応 / 無料配信可 / 有料配信可 / 会員制配信可</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <ul class="pricing-notes">
+        <li>※ 作品の保護(コピーガード)が必要な場合は、Proプランをお選びください。</li>
+        <li>※ ご試用の期間中に限り、半年まで完全無料でご利用いただけます。半年以内でも本番稼働後は有料となります。</li>
+        <li>※ 銀行振込をご希望の方は、年額プラン(先払い・解約不可)でのご契約に限らせていただきます。月額プランをご希望の方は、クレジットカード決済をご利用ください。</li>
+        <li>※ 転送量・保存容量が超過した場合は、別途、追加費用を頂きます。詳細はご相談ください。</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section class="section" id="faq">
+    <div class="container">
+      <h2 class="section-title">よくあるご質問</h2>
+      <div class="faq-list">
+        <details>
+          <summary>コピーガードとは、どのような仕組みですか?</summary>
+          <p>映像を暗号化し、許可された視聴者の端末にだけ再生の鍵を渡す仕組みです。大手動画配信サービスでも採用されている業界標準の保護技術で、不正なコピーやダウンロード保存を防ぎます。</p>
+        </details>
+        <details>
+          <summary>海外のファンも視聴できますか?</summary>
+          <p>視聴自体は可能ですが、国内の自社設備から配信しているため、海外からの再生は速度が遅くなる場合があります。海外向けの本格的な展開をお考えの場合は、事前にご相談ください。</p>
+        </details>
+        <details>
+          <summary>既存の公式サイトや会員基盤と組み合わせられますか?</summary>
+          <p>可能です。発行される埋め込みコードで既存の公式サイトに動画を設置できるほか、既存の会員の仕組みと連携して「会員だけが再生できる」構成も実現できます。詳細は構成に応じてご提案します。</p>
+        </details>
+        <details>
+          <summary>配信できるコンテンツの基準はありますか?</summary>
+          <p>完全な国産プラットフォームですので、日本法を遵守したコンテンツであれば原則として配信可能です。個別のケースはお問い合わせください。</p>
+        </details>
+        <details>
+          <summary>可用性はどの程度ですか?</summary>
+          <p>大手クラウド・大手CDNと比べると、可用性やデータの完全性の面では劣ります。そのぶん低コストな配信を実現しています。高可用性が必要な作品・企画の場合は、事前にご相談ください。</p>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta-band" id="contact">
+    <div class="container">
+      <h2>作品の話を、聞かせてください。</h2>
+      <p>現在ローンチ直後のため、お申し込みは原則として紹介制とさせていただいております。作品の保護方針や配信企画に応じて、最適な構成をご提案します。まずはお気軽にご相談ください。</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="https://cream.co.jp/">導入のご相談(株式会社クリーム)</a>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<footer class="site-footer">
+  <div class="container">
+    <div class="footer-columns">
+      <div>
+        <h3>Filma</h3>
+        <ul>
+          <li><a href="https://docs.filma.biz/">サービス紹介・ドキュメント</a></li>
+          <li><a href="https://docs.filma.biz/admin-manual/">管理画面マニュアル</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>他の用途で探す</h3>
+        <ul>
+          <li><a href="/">開発者・開発会社の方へ</a></li>
+          <li><a href="/lp/elearning/">eラーニング・社内研修での利用</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>規約・提供会社</h3>
+        <ul>
+          <li><a href="https://docs.filma.biz/terms_of_service_template">ご利用規約</a></li>
+          <li><a href="https://docs.filma.biz/service_level_agreement">サービスレベルアグリーメント</a></li>
+          <li><a href="https://cream.co.jp/">株式会社クリーム</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-copy">Filma — 動画配信プラットフォーム / 提供: 株式会社クリーム</div>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/lp/ip/index.html
+++ b/lp/ip/index.html
@@ -17,7 +17,7 @@
 
 <header class="site-header">
   <div class="container">
-    <a class="brand" href="/lp/ip/">Filma<span>.</span></a>
+    <a class="brand" href="/">Filma<span>.</span></a>
     <nav class="global-nav">
       <a href="#protection">保護の仕組み</a>
       <a href="#business">配信のかたち</a>

--- a/scripts/preview-pages
+++ b/scripts/preview-pages
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Preview the GitHub Pages top page (index.html) locally with the same
+# directory layout it gets when published to docs.filma.biz.
+#
+# index.html references assets via absolute paths like /lp/assets/lp-common.css,
+# so opening the file directly (file://) does not reproduce the published state.
+# This script assembles a publish-like tree and serves it over HTTP.
+#
+# Usage:
+#   scripts/preview-pages [port]   # default port: 8000
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="$ROOT/.preview"
+PORT="${1:-8000}"
+
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+# Top page
+cp -f "$ROOT/index.html" "$OUT/index.html"
+
+# Landing page assets (developers is the root LP; elearning / ip live under /lp/)
+if [ -d "$ROOT/lp" ]; then
+  cp -a "$ROOT/lp" "$OUT/lp"
+fi
+
+# Custom domain marker (harmless locally, keeps parity with publish/)
+if [ -f "$ROOT/CNAME" ]; then
+  cp -f "$ROOT/CNAME" "$OUT/CNAME"
+fi
+
+# Other root markdown pages that are published alongside the LP
+find "$ROOT" -maxdepth 1 -type f -name '*.md' \
+  ! -name 'README.md' \
+  ! -name 'api_specification.md' \
+  -exec cp -f {} "$OUT/" \;
+
+echo "Preview ready at http://localhost:${PORT}/"
+echo "  top page      -> http://localhost:${PORT}/"
+echo "  elearning LP  -> http://localhost:${PORT}/lp/elearning/"
+echo "  ip LP         -> http://localhost:${PORT}/lp/ip/"
+echo "(Ctrl+C to stop)"
+
+cd "$OUT"
+exec python3 -m http.server "$PORT"


### PR DESCRIPTION
## 概要
`docs.filma.biz/` のトップページを開発者向けランディングページ（`index.html`）に設定します。
レビュー指摘を受け、**最新 master から作り直し**、現行の Jekyll/MkDocs Pages 構成（`.github/workflows/pages.yml`）に合わせました。旧ブランチにあった README のLP化・`technical-overview.md`・`contact-form.md`・`assets/images/*.svg` は本PRから外しています。

## 各ファイルの責務・対応URL
| ファイル | 対応URL / 役割 |
|---|---|
| `index.html` | `https://docs.filma.biz/` — サイトのトップページ（開発者向けLP） |
| `lp/assets/*.css` | LP共通・テーマCSS。`index.html` が絶対パス `/lp/assets/...` で参照 |
| `lp/elearning/index.html` | `https://docs.filma.biz/lp/elearning/` — eラーニング向けLP |
| `lp/ip/index.html` | `https://docs.filma.biz/lp/ip/` — IPホルダー向けLP |
| `README.md` | **リポジトリ説明として維持**。Pages のトップには使わない（`index.md` 生成をやめた） |
| `CNAME` | カスタムドメイン `docs.filma.biz`。`keep_files:false` でも維持するためソース管理下に配置 |
| `scripts/preview-pages` | ローカルpreview用スクリプト |

※ `technical-overview.md` は README と重複するため追加しません。

## Pages workflow の変更（`.github/workflows/pages.yml`）
- `on.push.paths` / `on.pull_request.paths` に `index.html` / `lp/**` / `CNAME` を追加（LP変更でbuildが走るように）
- `Prepare publish directory`:
  - `README.md -> publish/index.md` を廃止
  - `index.html -> publish/index.html`（トップページを一本化）
  - `lp/ -> publish/lp/`、`CNAME -> publish/CNAME` をコピー
- `Deploy`: `keep_files: true` → **`false`**（`gh-pages` 側に残る旧 `index.md` を一掃）。CNAME はソースから配布するのでドメインは維持

## ローカルでのpreview方法
`index.html` は `/lp/assets/...` の絶対パスを使うため、ファイル直開き（file://）では公開時と同じ状態になりません。公開時と同じ `publish/` 構成を組んでHTTP配信します。

\`\`\`bash
scripts/preview-pages          # http://localhost:8000/
scripts/preview-pages 8137     # ポート指定も可
\`\`\`

- トップ: http://localhost:8000/
- eラーニングLP: http://localhost:8000/lp/elearning/
- IPホルダーLP: http://localhost:8000/lp/ip/

検証済み: トップ / `/lp/assets/lp-common.css` / `/lp/elearning/` / `/lp/ip/` すべて HTTP 200、トップがLPを配信。

## デプロイについて
`pages.yml` のデプロイstepは `push` かつ `master` のときのみ実行されます。本PR（PR build）では `gh-pages` は変更されません。マージ後の `master` push で本番反映されます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)