### PR TITLE
docs: API仕様書の不整合を修正

### DIFF
--- a/api-spec/docs/02-authentication.md
+++ b/api-spec/docs/02-authentication.md
@@ -93,10 +93,10 @@ curl -X POST "https://filma.biz/filmaapi/token?api_key=your_api_key" \
 **レスポンス例:**
 ```json
 {
-  "token": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJvcmdhbml6YXRpb25faWQiOjEsImV4cCI6MTcwNDAwNzIwMCwiaWF0IjoxNzAzOTIwODAwfQ.signature",
+  "token": "eyJhbGciOiJIUzI1NiJ9...signature",
   "token_type": "Bearer",
-  "expires_in": 86400,
-  "expires_at": 1704007200,
+  "expires_in": 3600,
+  "expires_at": 1703924400,
   "user_id": 1,
   "organization_id": 1,
   "api_type": "readonly"
@@ -165,4 +165,3 @@ curl -H "Referer: https://any-domain.com/video.html" \
 - **トークンリフレッシュ**: 有効なトークンから新しいトークンを発行可能
 - **Cookie自動設定**: HTTPS環境でのJWTトークン発行時にCookieが自動設定される
 - **CSRF保護**: SameSite=Lax設定により、外部サイトからのPOSTリクエストを自動的に保護
-

--- a/api-spec/docs/04-endpoints.md
+++ b/api-spec/docs/04-endpoints.md
@@ -69,10 +69,10 @@ curl -X POST "https://filma.biz/filmaapi/token" \
 **成功時（HTTP 200）**
 ```json
 {
-  "token": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJleHAiOjE3MDQwMDcyMDAsImlhdCI6MTcwMzkyMDgwMCwibWVkaWFmaWxlX2lkIjoxMjM0NX0.signature",
+  "token": "eyJhbGciOiJIUzI1NiJ9...signature",
   "token_type": "Bearer",
-  "expires_in": 86400,
-  "expires_at": 1704007200,
+  "expires_in": 7200,
+  "expires_at": 1703928000,
   "user_id": 1,
   "organization_id": 1,
   "api_type": "readonly",
@@ -91,7 +91,7 @@ curl -X POST "https://filma.biz/filmaapi/token" \
   "auth_method": "api_key",
   "mediafile_id": 12345,
   "iat": 1703920800,
-  "exp": 1704007200
+  "exp": 1703928000
 }
 ```
 
@@ -207,10 +207,10 @@ curl -X POST "https://filma.biz/filmaapi/token/refresh" \
 **成功時（HTTP 200）**
 ```json
 {
-  "token": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxLCJvcmdhbml6YXRpb25faWQiOjEsImV4cCI6MTcwNDAwNzIwMCwiaWF0IjoxNzAzOTIwODAwfQ.new_signature",
+  "token": "eyJhbGciOiJIUzI1NiJ9...new_signature",
   "token_type": "Bearer",
-  "expires_in": 86400,
-  "expires_at": 1704093600,
+  "expires_in": 3600,
+  "expires_at": 1703924400,
   "user_id": 1,
   "organization_id": 1,
   "api_type": "readonly"
@@ -769,7 +769,7 @@ GET /filmaapi/storage/folders/{id}
 | creator | string | フォルダ作成者名 |
 | updater | string | フォルダ更新者名 |
 
-#### ファイルアップロード
+#### ファイルアップロード（未実装）
 
 ```
 POST /filmaapi/storage
@@ -827,7 +827,7 @@ DELETE /filmaapi/storage/{id}
 - 削除されたファイルは、通常のAPI呼び出しでは取得できなくなります
 - 削除されたファイルは、配信対象外として扱われます
 
-### Encode API
+### Encode API（未実装）
 
 動画エンコーディングの管理を行います。
 

--- a/api-spec/docs/08-cautions.md
+++ b/api-spec/docs/08-cautions.md
@@ -1,7 +1,7 @@
 # 注意事項
 
 - APIキー認証またはJWT認証が各リクエストに必要です
-- JWT認証は2つの方法（Authorization header、Cookie）で利用可能です
+- JWT認証は3つの方法（Authorizationヘッダー、`filmajwt` Cookie、`jwt`クエリパラメータ）で利用可能です
 - 管理画面にログインすると、JWTトークンが自動でCookieに設定されます
 - fullaccess権限が必要な操作は明記されています
 - ページングは最大100件まで取得可能です


### PR DESCRIPTION
## 概要

Filma API仕様書内のJWT認証方法、有効期限の例、未実装APIの表記を整合させます。

## 変更内容

- JWT認証方式を3種類（Authorizationヘッダー、`filmajwt` Cookie、`jwt`クエリパラメータ）の記述に統一
- JWT発行・更新レスポンスの有効期限を、既定値またはリクエスト例の指定値と一致するよう修正
- サンプルJWTを省略表記にして、ペイロード例との不一致を解消
- ファイルアップロードとEncode APIの見出しに「未実装」を明記

## 変更理由

概要・注意事項・エンドポイント例の間で記述が一致しておらず、利用者やドキュメントを参照するAIが誤った認証方法、有効期限、実装状況を解釈する可能性があったためです。

## 影響

ドキュメントのみの変更です。Filma APIおよび管理画面の動作には影響しません。

## 検証

- `git diff --check`
- 変更したJSONレスポンス例を `jq` で構文検証
- JWTの `iat` / `exp` と `expires_in` の時刻差を確認

MkDocsはローカル環境にインストールされていないため、サイト全体のビルドは実施していません。