### PR TITLE
Fix Context7 ownership claim: drop $schema from context7.json

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/moguracream/filma-docs",
   "public_key": "pk_zFFhrI6maG2MP9MTZWoJg",
   "projectTitle": "Filma",


### PR DESCRIPTION
Claim 実行時に検証が失敗したため修正します。

```
Verification Failed
context7.json format is incorrect for claiming
Requires "url" and "public_key". Known config fields are allowed, but unknown fields are not.
```

## 原因

`url` と `public_key` は master 上の `context7.json` に含まれており、[raw で取得できる](https://raw.githubusercontent.com/moguracream/filma-docs/master/context7.json)ことも確認済みです。ファイルが見つからない類のエラーではありません。

問題は `$schema` フィールドです。公開されている [JSON Schema](https://context7.com/schema/context7.json) には `$schema` が `properties` として定義されており（エディタの補完用）、[ドキュメント](https://context7.com/docs/library-owners)でも記載が推奨されています。しかし claim 時のバリデータは「設定フィールドの許可リスト」で検証しており、そこに `$schema` は含まれていないと見られます。ファイル内で設定フィールドでないキーは `$schema` だけです。

## 変更

`$schema` の1行を削除しました。残りの `url` / `public_key` / `projectTitle` / `description` / `branch` / `folders` / `excludeFolders` / `excludeFiles` / `rules` はすべてスキーマに定義された設定フィールドなので、パース設定はこれまでどおりリポジトリ側で管理できます。

副作用として、エディタ上での `context7.json` の補完・検証は効かなくなります。

## マージ後

https://context7.com/moguracream/filma-docs/admin で再度「Claim Library」を実行してください。

これでも同じエラーが出る場合は、いったん `{"url": ..., "public_key": ...}` の2フィールドだけに減らして claim を通し、その後に設定フィールドを戻す手順に切り替えます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)