### PR TITLE
Reduce context7.json to the documented claim payload

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,33 +1,4 @@
 {
   "url": "https://context7.com/moguracream/filma-docs",
-  "public_key": "pk_zFFhrI6maG2MP9MTZWoJg",
-  "projectTitle": "Filma",
-  "description": "動画配信プラットフォーム Filma (PaaS) の API 仕様書・管理マニュアル・実装テンプレート。MPEG-DASH によるアダプティブストリーミングとマルチ DRM (Widevine / PlayReady / FairPlay) に対応し、Storage / Player / DASH / HLS / DRM ライセンス / Customers / Entitlements の各 API と、動画の埋め込み・署名付き URL・会員/視聴権管理の実装方法を提供します。",
-  "branch": "master",
-  "folders": [
-    "api-spec/docs",
-    "admin-manual/docs",
-    "template-jwt",
-    "template-no-auth"
-  ],
-  "excludeFolders": [
-    "lp",
-    "scripts",
-    "assets",
-    "**/site"
-  ],
-  "excludeFiles": [
-    "api_specification.md",
-    "service_level_agreement.md",
-    "terms_of_service_template.md"
-  ],
-  "rules": [
-    "API のベース URL は https://filma.biz/filmaapi 、レスポンスは JSON、日時は ISO 8601 形式",
-    "すべてのリクエストで認証が必要。API キー認証 (X-Api-Key ヘッダーまたは api_key クエリパラメータ) と JWT 認証 (Authorization: Bearer / filmajwt Cookie / jwt クエリパラメータ) のいずれかを使う",
-    "API キーと JWT の両方が渡された場合は API キー認証が優先される。ブラウザに古い JWT が残っていても API キーがあれば無視される",
-    "ドメインアクセス制限は API キー認証にのみ適用される。JWT 認証には適用されない",
-    "一覧系エンドポイントの per_page は最大 100 件。100 を超える値を指定すると既定の 20 件に丸められる",
-    "非公開ファイルを含めて取得するには show_all=true と fullaccess 権限の両方が必要。公開期限 (published_until) 切れのファイルは公開扱いにならない",
-    "本番環境では API キーをフロントエンドに露出させず、バックエンドで短期 JWT を発行する。template-jwt は動作確認のために JWT 発行処理を JavaScript で実装したデモであり、そのまま本番利用しない"
-  ]
+  "public_key": "pk_zFFhrI6maG2MP9MTZWoJg"
 }


### PR DESCRIPTION
PR #28（`$schema` 削除）をマージしても claim 検証が同じエラーで失敗するため、確実に通る最小構成に落とします。

```
Requires "url" and "public_key". Known config fields are allowed, but unknown fields are not.
```

## 調べた結果わかっていること

- master 上のファイルから `$schema` は削除済み（raw / GitHub API の両方で確認）。よって `$schema` 原因説は**否定された**
- 残りのキー（`projectTitle` `description` `branch` `folders` `excludeFolders` `excludeFiles` `rules`）は、すべて[公開 JSON Schema](https://context7.com/schema/context7.json) の `properties` に定義されており、[管理画面の設定項目表](https://context7.com/docs/howto/claiming-libraries)にも対応する項目がある
- ドキュメント記載の文字数・件数上限もすべてクリア（projectTitle 5/100、description 242/500、rules 7件・最長136/255 文字 など）
- claim のトラブルシューティングに載っているのは "context7.json not found" / "URL mismatch" / "Public key mismatch" の3種のみで、今回のエラーは記載なし

つまり**どのフィールドが unknown 扱いされているのかを外部から特定する手がかりがありません**。1フィールドずつ削って試すと毎回マージが必要になるため、その方法は取りません。

## 変更

ドキュメントの claim 手順に記載されている2フィールドだけに減らします。

```json
{
  "url": "https://context7.com/moguracream/filma-docs",
  "public_key": "pk_zFFhrI6maG2MP9MTZWoJg"
}
```

パース設定は失われません。git 履歴に残っており、claim 成功後にフォローアップ PR で戻します。

## マージ後

1. https://context7.com/moguracream/filma-docs/admin で「Claim Library」を実行
2. 成功したら、パース設定（`folders` / `excludeFolders` / `excludeFiles` / `rules` など）を戻す PR を出します

claim 後に設定フィールドを戻して弾かれる場合は、モーダルの設定管理方式を「context7.json」から「Web UI」に切り替えて管理画面側で設定する運用になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)