### PR TITLE
Add GA4 contact attribution for media and ads

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,8 @@ on:
       - 'template-no-auth/**'
       - 'index.html'
       - 'lp/**'
+      - 'assets/**'
+      - 'contact/**'
       - 'CNAME'
       - '*.md'
       - '_config.yml'
@@ -23,6 +25,10 @@ on:
       - 'template-no-auth/**'
       - 'index.html'
       - 'lp/**'
+      - 'assets/**'
+      - 'contact/**'
+      - 'scripts/test-contact-redirect.mjs'
+      - 'scripts/test-homepage-pricing.mjs'
       - 'CNAME'
       - '*.md'
       - '_config.yml'
@@ -42,6 +48,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Test static pages
+        run: |
+          node scripts/test-contact-redirect.mjs
+          node scripts/test-homepage-pricing.mjs
 
       - name: Check docs source
         id: docs-source
@@ -108,6 +124,14 @@ jobs:
           # Landing page assets (absolute /lp/... paths in index.html rely on this).
           if [ -d lp ]; then
             cp -a lp publish/lp
+          fi
+
+          # Contact redirect endpoint and its JavaScript module.
+          if [ -d contact ]; then
+            cp -a contact publish/contact
+          fi
+          if [ -d assets ]; then
+            cp -a assets publish/assets
           fi
 
           find . -maxdepth 1 -type f -name '*.md' \

--- a/assets/js/contact-redirect.mjs
+++ b/assets/js/contact-redirect.mjs
@@ -1,0 +1,151 @@
+export const UTM_PARAMETER_NAMES = Object.freeze([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_id",
+  "utm_term",
+  "utm_source_platform",
+]);
+
+export const DEFAULT_CLICK_ID_NAMES = Object.freeze([
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "dclid",
+  "gclsrc",
+]);
+
+const UTM_VALUE_PATTERN = /^[A-Za-z0-9._-]+$/;
+const CLICK_ID_VALUE_PATTERN = /^[A-Za-z0-9._~-]+$/;
+const FORM_ENTRY_KEY_PATTERN = /^entry\.\d+$/;
+
+function copyValidValues(source, destination, names, pattern, maxLength) {
+  const values = {};
+
+  for (const name of names) {
+    const value = source.get(name);
+    if (!value || value.length > maxLength || !pattern.test(value)) continue;
+
+    destination.set(name, value);
+    values[name] = value;
+  }
+
+  return values;
+}
+
+export function sanitizeAttribution(
+  search,
+  enabledClickIdNames = DEFAULT_CLICK_ID_NAMES,
+) {
+  const source = new URLSearchParams(search);
+  const params = new URLSearchParams();
+  const utm = copyValidValues(
+    source,
+    params,
+    UTM_PARAMETER_NAMES,
+    UTM_VALUE_PATTERN,
+    100,
+  );
+  const clickIds = copyValidValues(
+    source,
+    params,
+    enabledClickIdNames,
+    CLICK_ID_VALUE_PATTERN,
+    512,
+  );
+
+  return {
+    params,
+    utm,
+    clickIds,
+    flowCode: utm.utm_content || "",
+  };
+}
+
+export function buildSanitizedPageUrl(currentUrl, params) {
+  const url = new URL(currentUrl);
+  url.search = params.toString();
+  url.hash = "";
+  return url.href;
+}
+
+export function buildFormUrl(baseUrl, entryKey, flowCode) {
+  const url = new URL(baseUrl);
+  url.search = "";
+  url.hash = "";
+  url.searchParams.set("usp", "pp_url");
+
+  if (flowCode && FORM_ENTRY_KEY_PATTERN.test(entryKey)) {
+    url.searchParams.set(entryKey, flowCode);
+  }
+
+  return url.href;
+}
+
+export function startContactRedirect({
+  window,
+  document,
+  location,
+  history,
+  measurementId,
+  formBaseUrl,
+  formEntryKey,
+  timeoutMs = 1000,
+  enabledClickIdNames = DEFAULT_CLICK_ID_NAMES,
+}) {
+  const attribution = sanitizeAttribution(
+    location.search,
+    enabledClickIdNames,
+  );
+  const sanitizedPageUrl = buildSanitizedPageUrl(
+    location.href,
+    attribution.params,
+  );
+  const formUrl = buildFormUrl(
+    formBaseUrl,
+    formEntryKey,
+    attribution.flowCode,
+  );
+
+  history.replaceState(null, "", sanitizedPageUrl);
+
+  const manualLink = document.getElementById("manual-contact-link");
+  if (manualLink) manualLink.href = formUrl;
+
+  const googleTagScript = document.createElement("script");
+  googleTagScript.async = true;
+  googleTagScript.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(measurementId)}`;
+  document.head.append(googleTagScript);
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag =
+    window.gtag ||
+    function gtag() {
+      window.dataLayer.push(arguments);
+    };
+
+  let redirected = false;
+  const redirect = () => {
+    if (redirected) return;
+    redirected = true;
+    location.replace(formUrl);
+  };
+
+  window.gtag("js", new Date());
+  window.gtag("config", measurementId, {
+    page_location: sanitizedPageUrl,
+  });
+  window.gtag("event", "contact_redirect", {
+    event_callback: redirect,
+    event_timeout: timeoutMs,
+    transport_type: "beacon",
+  });
+  window.setTimeout(redirect, timeoutMs);
+
+  return {
+    sanitizedPageUrl,
+    formUrl,
+    redirect,
+  };
+}

--- a/assets/js/contact-redirect.mjs
+++ b/assets/js/contact-redirect.mjs
@@ -14,6 +14,8 @@ export const DEFAULT_CLICK_ID_NAMES = Object.freeze([
   "wbraid",
   "dclid",
   "gclsrc",
+  "gad_source",
+  "gad_campaignid",
 ]);
 
 const UTM_VALUE_PATTERN = /^[A-Za-z0-9._-]+$/;

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex,nofollow">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
+  <title>お問い合わせフォームへ移動しています | Filma</title>
+  <style>
+    :root {
+      color-scheme: light;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      color: #172033;
+      background: #f5f7fb;
+    }
+
+    body {
+      min-height: 100vh;
+      margin: 0;
+      display: grid;
+      place-items: center;
+    }
+
+    main {
+      width: min(34rem, calc(100% - 3rem));
+      padding: 2.5rem 2rem;
+      border: 1px solid #dce2ec;
+      border-radius: 1rem;
+      background: #fff;
+      box-shadow: 0 1rem 3rem rgba(23, 32, 51, 0.08);
+      text-align: center;
+    }
+
+    h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(1.4rem, 4vw, 2rem);
+      line-height: 1.4;
+    }
+
+    p {
+      margin: 0 0 1.5rem;
+      line-height: 1.8;
+      color: #526079;
+    }
+
+    a {
+      display: inline-block;
+      padding: 0.8rem 1.2rem;
+      border-radius: 0.65rem;
+      color: #fff;
+      background: #2459d3;
+      font-weight: 700;
+      text-decoration: none;
+    }
+
+    a:focus-visible {
+      outline: 3px solid #8eb2ff;
+      outline-offset: 3px;
+    }
+  </style>
+</head>
+<body>
+  <main aria-live="polite">
+    <h1>お問い合わせフォームへ移動しています</h1>
+    <p>自動的に移動しない場合は、以下のリンクを押してください。</p>
+    <a
+      id="manual-contact-link"
+      href="https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform"
+      rel="noopener noreferrer"
+    >お問い合わせフォームを開く</a>
+    <noscript>
+      <p>JavaScriptが無効なため、自動移動できません。上のリンクからフォームを開いてください。</p>
+    </noscript>
+  </main>
+
+  <script type="module">
+    import { startContactRedirect } from "/assets/js/contact-redirect.mjs";
+
+    startContactRedirect({
+      window,
+      document,
+      location,
+      history,
+      measurementId: "G-1KZJ2QN1S7",
+      formBaseUrl: "https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform",
+      formEntryKey: "entry.1442019456",
+      timeoutMs: 1000,
+    });
+  </script>
+</body>
+</html>

--- a/contact/index.html
+++ b/contact/index.html
@@ -22,6 +22,7 @@
     }
 
     main {
+      box-sizing: border-box;
       width: min(34rem, calc(100% - 3rem));
       padding: 2.5rem 2rem;
       border: 1px solid #dce2ec;

--- a/scripts/test-contact-redirect.mjs
+++ b/scripts/test-contact-redirect.mjs
@@ -10,7 +10,7 @@ async function loadModule() {
 test("keeps valid manual campaign parameters and Google click IDs", async () => {
   const { sanitizeAttribution } = await loadModule();
   const result = sanitizeAttribution(
-    "?utm_source=google&utm_medium=cpc&utm_campaign=filma_search_general_202609_drm&utm_content=responsive_ad_a&utm_id=search_001&utm_term=video_drm&utm_source_platform=google_ads&gclid=AbC_123-xy&gbraid=GBR.456&wbraid=WBR~789&dclid=DCL_123&gclsrc=aw.ds&email=person%40example.com&next=https%3A%2F%2Fevil.example",
+    "?utm_source=google&utm_medium=cpc&utm_campaign=filma_search_general_202609_drm&utm_content=responsive_ad_a&utm_id=search_001&utm_term=video_drm&utm_source_platform=google_ads&gclid=AbC_123-xy&gbraid=GBR.456&wbraid=WBR~789&dclid=DCL_123&gclsrc=aw.ds&gad_source=1&gad_campaignid=1234567890&email=person%40example.com&next=https%3A%2F%2Fevil.example",
   );
 
   assert.deepEqual(result.utm, {
@@ -28,6 +28,8 @@ test("keeps valid manual campaign parameters and Google click IDs", async () => 
     wbraid: "WBR~789",
     dclid: "DCL_123",
     gclsrc: "aw.ds",
+    gad_source: "1",
+    gad_campaignid: "1234567890",
   });
   assert.equal(result.flowCode, "responsive_ad_a");
   assert.equal(result.params.has("email"), false);

--- a/scripts/test-contact-redirect.mjs
+++ b/scripts/test-contact-redirect.mjs
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const moduleUrl = new URL("../assets/js/contact-redirect.mjs", import.meta.url);
+
+async function loadModule() {
+  return import(moduleUrl.href);
+}
+
+test("keeps valid manual campaign parameters and Google click IDs", async () => {
+  const { sanitizeAttribution } = await loadModule();
+  const result = sanitizeAttribution(
+    "?utm_source=google&utm_medium=cpc&utm_campaign=filma_search_general_202609_drm&utm_content=responsive_ad_a&utm_id=search_001&utm_term=video_drm&utm_source_platform=google_ads&gclid=AbC_123-xy&gbraid=GBR.456&wbraid=WBR~789&dclid=DCL_123&gclsrc=aw.ds&email=person%40example.com&next=https%3A%2F%2Fevil.example",
+  );
+
+  assert.deepEqual(result.utm, {
+    utm_source: "google",
+    utm_medium: "cpc",
+    utm_campaign: "filma_search_general_202609_drm",
+    utm_content: "responsive_ad_a",
+    utm_id: "search_001",
+    utm_term: "video_drm",
+    utm_source_platform: "google_ads",
+  });
+  assert.deepEqual(result.clickIds, {
+    gclid: "AbC_123-xy",
+    gbraid: "GBR.456",
+    wbraid: "WBR~789",
+    dclid: "DCL_123",
+    gclsrc: "aw.ds",
+  });
+  assert.equal(result.flowCode, "responsive_ad_a");
+  assert.equal(result.params.has("email"), false);
+  assert.equal(result.params.has("next"), false);
+});
+
+test("rejects malformed and overlong values without blocking valid attribution", async () => {
+  const { sanitizeAttribution } = await loadModule();
+  const overlongUtm = "a".repeat(101);
+  const overlongClickId = "b".repeat(513);
+  const result = sanitizeAttribution(
+    `?utm_source=google&utm_medium=paid%20search&utm_campaign=${overlongUtm}&utm_content=creative%2Fone&gclid=${overlongClickId}&gbraid=Valid_123`,
+  );
+
+  assert.deepEqual(result.utm, { utm_source: "google" });
+  assert.deepEqual(result.clickIds, { gbraid: "Valid_123" });
+  assert.equal(result.flowCode, "");
+  assert.equal(result.params.toString(), "utm_source=google&gbraid=Valid_123");
+});
+
+test("keeps only the first value for duplicate allowlisted parameters", async () => {
+  const { sanitizeAttribution } = await loadModule();
+  const result = sanitizeAttribution(
+    "?utm_source=google&utm_source=spoofed&gclid=FirstValue&gclid=SecondValue",
+  );
+
+  assert.equal(result.params.get("utm_source"), "google");
+  assert.equal(result.params.getAll("utm_source").length, 1);
+  assert.equal(result.params.get("gclid"), "FirstValue");
+  assert.equal(result.params.getAll("gclid").length, 1);
+});
+
+test("does not retain disabled platform click IDs unless explicitly enabled", async () => {
+  const { sanitizeAttribution, DEFAULT_CLICK_ID_NAMES } = await loadModule();
+  const query = "?utm_source=bing&utm_medium=cpc&msclkid=MsClick_123&fbclid=FbClick_456";
+
+  const defaultResult = sanitizeAttribution(query);
+  assert.deepEqual(defaultResult.clickIds, {});
+
+  const enabledResult = sanitizeAttribution(query, [
+    ...DEFAULT_CLICK_ID_NAMES,
+    "msclkid",
+    "fbclid",
+  ]);
+  assert.deepEqual(enabledResult.clickIds, {
+    msclkid: "MsClick_123",
+    fbclid: "FbClick_456",
+  });
+});
+
+test("builds a sanitized page URL and a form URL that receives only the management code", async () => {
+  const {
+    buildFormUrl,
+    buildSanitizedPageUrl,
+    sanitizeAttribution,
+  } = await loadModule();
+  const result = sanitizeAttribution(
+    "?utm_source=google&utm_medium=cpc&utm_content=responsive_ad_a&gclid=AbC_123-xy&next=https%3A%2F%2Fevil.example",
+  );
+
+  const pageUrl = buildSanitizedPageUrl(
+    "https://docs.filma.biz/contact/?old=value#fragment",
+    result.params,
+  );
+  assert.equal(
+    pageUrl,
+    "https://docs.filma.biz/contact/?utm_source=google&utm_medium=cpc&utm_content=responsive_ad_a&gclid=AbC_123-xy",
+  );
+
+  const formUrl = buildFormUrl(
+    "https://docs.google.com/forms/d/e/form-id/viewform?unexpected=value",
+    "entry.1442019456",
+    result.flowCode,
+  );
+  assert.equal(
+    formUrl,
+    "https://docs.google.com/forms/d/e/form-id/viewform?usp=pp_url&entry.1442019456=responsive_ad_a",
+  );
+  assert.equal(formUrl.includes("utm_source="), false);
+  assert.equal(formUrl.includes("gclid="), false);
+  assert.equal(formUrl.includes("next="), false);
+});
+
+test("omits the management code when utm_content is absent", async () => {
+  const { buildFormUrl } = await loadModule();
+  const formUrl = buildFormUrl(
+    "https://docs.google.com/forms/d/e/form-id/viewform",
+    "entry.1442019456",
+    "",
+  );
+
+  assert.equal(
+    formUrl,
+    "https://docs.google.com/forms/d/e/form-id/viewform?usp=pp_url",
+  );
+});
+
+function createBrowserHarness(search) {
+  const order = [];
+  const gtagCalls = [];
+  const timerCallbacks = [];
+  const replacedLocations = [];
+  const manualLink = { href: "" };
+  const location = {
+    href: `https://docs.filma.biz/contact/${search}`,
+    search,
+    replace(url) {
+      order.push("location.replace");
+      replacedLocations.push(url);
+    },
+  };
+  const history = {
+    replaceState(_state, _title, url) {
+      order.push("history.replaceState");
+      location.href = url;
+      location.search = new URL(url).search;
+    },
+  };
+  const document = {
+    head: {
+      append(script) {
+        order.push("document.head.append");
+        assert.equal(script.async, true);
+        assert.equal(
+          script.src,
+          "https://www.googletagmanager.com/gtag/js?id=G-1KZJ2QN1S7",
+        );
+      },
+    },
+    createElement(tagName) {
+      assert.equal(tagName, "script");
+      return { async: false, src: "" };
+    },
+    getElementById(id) {
+      assert.equal(id, "manual-contact-link");
+      return manualLink;
+    },
+  };
+  const dataLayer = {
+    push(args) {
+      const call = Array.from(args);
+      gtagCalls.push(call);
+      const suffix = call[0] === "js" || !call[1] ? "" : `.${call[1]}`;
+      order.push(`gtag.${call[0]}${suffix}`);
+    },
+  };
+  const window = {
+    dataLayer,
+    setTimeout(callback, delay) {
+      order.push("window.setTimeout");
+      assert.equal(delay, 1000);
+      timerCallbacks.push(callback);
+      return timerCallbacks.length;
+    },
+  };
+
+  return {
+    document,
+    gtagCalls,
+    history,
+    location,
+    manualLink,
+    order,
+    replacedLocations,
+    timerCallbacks,
+    window,
+  };
+}
+
+test("initializes GA4 with the sanitized page URL before redirecting", async () => {
+  const { startContactRedirect } = await loadModule();
+  const harness = createBrowserHarness(
+    "?utm_source=google&utm_medium=cpc&utm_campaign=filma_search_general_202609_drm&utm_content=responsive_ad_a&utm_id=search_001&utm_term=video_drm&utm_source_platform=google_ads&gclid=AbC_123-xy&next=https%3A%2F%2Fevil.example",
+  );
+
+  const result = startContactRedirect({
+    ...harness,
+    measurementId: "G-1KZJ2QN1S7",
+    formBaseUrl:
+      "https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform",
+    formEntryKey: "entry.1442019456",
+    timeoutMs: 1000,
+  });
+
+  assert.equal(result.sanitizedPageUrl.includes("gclid=AbC_123-xy"), true);
+  assert.equal(result.sanitizedPageUrl.includes("next="), false);
+  assert.equal(
+    result.formUrl,
+    "https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform?usp=pp_url&entry.1442019456=responsive_ad_a",
+  );
+  assert.equal(harness.manualLink.href, result.formUrl);
+  assert.deepEqual(harness.order, [
+    "history.replaceState",
+    "document.head.append",
+    "gtag.js",
+    "gtag.config.G-1KZJ2QN1S7",
+    "gtag.event.contact_redirect",
+    "window.setTimeout",
+  ]);
+  assert.equal(harness.gtagCalls.length, 3);
+  assert.equal(harness.gtagCalls[1][0], "config");
+  assert.equal(harness.gtagCalls[1][1], "G-1KZJ2QN1S7");
+  assert.equal(
+    harness.gtagCalls[1][2].page_location,
+    result.sanitizedPageUrl,
+  );
+  assert.equal(harness.gtagCalls[2][0], "event");
+  assert.equal(harness.gtagCalls[2][1], "contact_redirect");
+  assert.equal(harness.gtagCalls[2][2].event_timeout, 1000);
+  assert.equal(harness.gtagCalls[2][2].transport_type, "beacon");
+});
+
+test("redirects only once when both GA4 callback and fallback timer run", async () => {
+  const { startContactRedirect } = await loadModule();
+  const harness = createBrowserHarness(
+    "?utm_source=google&utm_medium=cpc&utm_content=responsive_ad_a&gclid=AbC_123-xy",
+  );
+
+  const result = startContactRedirect({
+    ...harness,
+    measurementId: "G-1KZJ2QN1S7",
+    formBaseUrl:
+      "https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform",
+    formEntryKey: "entry.1442019456",
+    timeoutMs: 1000,
+  });
+  const eventOptions = harness.gtagCalls[2][2];
+
+  eventOptions.event_callback();
+  harness.timerCallbacks[0]();
+  result.redirect();
+
+  assert.deepEqual(harness.replacedLocations, [result.formUrl]);
+});
+
+test("falls back to the timer when the Google tag never loads", async () => {
+  const { startContactRedirect } = await loadModule();
+  const harness = createBrowserHarness("?utm_source=referral");
+
+  const result = startContactRedirect({
+    ...harness,
+    measurementId: "G-1KZJ2QN1S7",
+    formBaseUrl:
+      "https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform",
+    formEntryKey: "entry.1442019456",
+    timeoutMs: 1000,
+  });
+
+  harness.timerCallbacks[0]();
+
+  assert.deepEqual(harness.replacedLocations, [result.formUrl]);
+  assert.equal(result.formUrl.endsWith("?usp=pp_url"), true);
+});


### PR DESCRIPTION
## 概要
QRコード、Webメディア、検索広告、SNS広告から問い合わせフォームへ遷移する際の流入情報を、GA4で一貫して計測する静的リダイレクトMVPです。

## 変更内容
- `/contact/` に静的リダイレクトページを追加
- UTM 7項目とGoogle広告クリックID（`gad_source` / `gad_campaignid` を含む）を検証・正規化
- GA4イベント `contact_redirect` を送信
- Googleフォームの「管理用コード（変更不要）」へ `utm_content` を事前入力
- リダイレクト処理の自動テストを追加
- GitHub Pagesのデプロイ対象に `contact/**` と `assets/**` を追加

## 影響範囲
- 問い合わせフォームへの遷移までを計測します
- Googleフォームの送信完了と `generate_lead` は対象外です
- 内部資料（`docs/superpowers/`、`business-info/`、`business-development/`）は含めていません

## 確認
- `node scripts/test-contact-redirect.mjs` — 9/9 passed
- `node scripts/test-homepage-pricing.mjs` — passed
- `git diff --check origin/master...HEAD` — passed
- 変更対象は公開・テスト・デプロイ用の4ファイルのみ
- ローカルブラウザでUTM・クリックIDの保持、不要パラメータ除去、Googleフォームへの管理用コード事前入力を確認