### PR TITLE
トップページの問い合わせ導線をGA4計測経由へ切り替え

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,6 +29,8 @@ on:
       - 'contact/**'
       - 'scripts/test-contact-redirect.mjs'
       - 'scripts/test-homepage-pricing.mjs'
+      - 'scripts/test-preview-pages.mjs'
+      - 'scripts/preview-pages'
       - 'CNAME'
       - '*.md'
       - '_config.yml'
@@ -58,6 +60,7 @@ jobs:
         run: |
           node scripts/test-contact-redirect.mjs
           node scripts/test-homepage-pricing.mjs
+          node scripts/test-preview-pages.mjs
 
       - name: Check docs source
         id: docs-source

--- a/assets/js/contact-redirect.mjs
+++ b/assets/js/contact-redirect.mjs
@@ -72,6 +72,21 @@ export function buildSanitizedPageUrl(currentUrl, params) {
   return url.href;
 }
 
+export function preserveAttributionOnContactLinks({
+  document,
+  location,
+  enabledClickIdNames = DEFAULT_CLICK_ID_NAMES,
+}) {
+  const { params } = sanitizeAttribution(
+    location.search,
+    enabledClickIdNames,
+  );
+
+  for (const link of document.querySelectorAll("[data-contact-link]")) {
+    link.href = buildSanitizedPageUrl(link.href, params);
+  }
+}
+
 export function buildFormUrl(baseUrl, entryKey, flowCode) {
   const url = new URL(baseUrl);
   url.search = "";

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
       <a href="#samples">サンプル</a>
       <a href="#pricing">料金</a>
       <a href="#faq">FAQ</a>
-      <a class="btn btn-primary btn-small" href="https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform" target="_blank" rel="noopener noreferrer">導入のご相談</a>
+      <a class="btn btn-primary btn-small" href="/contact/" data-contact-link target="_blank" rel="noopener noreferrer">導入のご相談</a>
     </nav>
   </div>
 </header>
@@ -43,7 +43,7 @@
       <h1>コピペで動く、<br>DRM付き動画配信API。</h1>
       <p class="lead">DRMで守るべき動画コンテンツを配信する事業者へ。Filmaは、有料映像・IPコンテンツ・会員限定動画を自社サービスで配信するための動画配信PaaSです。アップロードするだけでエンコードとマルチDRM暗号化が自動で完了します。</p>
       <div class="hero-cta">
-        <a class="btn btn-primary" href="https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform" target="_blank" rel="noopener noreferrer">導入のご相談(無料)</a>
+        <a class="btn btn-primary" href="/contact/" data-contact-link target="_blank" rel="noopener noreferrer">導入のご相談(無料)</a>
         <a class="btn btn-ghost" href="https://docs.filma.biz/api-spec/">APIリファレンスを見る</a>
       </div>
       <p class="hero-note">ご試用・開発期間中は半年まで完全無料。契約前にAPIとサンプルコードをお試しいただけます。</p>
@@ -320,7 +320,7 @@
       <h2>守るべき動画を、自社サービスで配信する。</h2>
       <p>有料映像、IPコンテンツ、会員限定動画へのDRM導入やAPI連携をご相談ください。ご試用・開発期間中は半年まで無料で、実際の動画とサンプルコードを使って検証できます。</p>
       <div class="hero-cta">
-        <a class="btn btn-primary" href="https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform" target="_blank" rel="noopener noreferrer">導入のご相談</a>
+        <a class="btn btn-primary" href="/contact/" data-contact-link target="_blank" rel="noopener noreferrer">導入のご相談</a>
         <a class="btn btn-ghost" href="https://docs.filma.biz/">ドキュメントを見る</a>
       </div>
     </div>
@@ -360,6 +360,12 @@
     <div class="footer-copy">Filma — 動画配信プラットフォーム (PaaS) / 提供: 株式会社クリーム</div>
   </div>
 </footer>
+
+<script type="module">
+  import { preserveAttributionOnContactLinks } from "/assets/js/contact-redirect.mjs";
+
+  preserveAttributionOnContactLinks({ document, location });
+</script>
 
 </body>
 </html>

--- a/scripts/preview-pages
+++ b/scripts/preview-pages
@@ -25,6 +25,14 @@ if [ -d "$ROOT/lp" ]; then
   cp -a "$ROOT/lp" "$OUT/lp"
 fi
 
+# Contact redirect endpoint and its shared JavaScript module.
+if [ -d "$ROOT/contact" ]; then
+  cp -a "$ROOT/contact" "$OUT/contact"
+fi
+if [ -d "$ROOT/assets" ]; then
+  cp -a "$ROOT/assets" "$OUT/assets"
+fi
+
 # Custom domain marker (harmless locally, keeps parity with publish/)
 if [ -f "$ROOT/CNAME" ]; then
   cp -f "$ROOT/CNAME" "$OUT/CNAME"
@@ -38,6 +46,7 @@ find "$ROOT" -maxdepth 1 -type f -name '*.md' \
 
 echo "Preview ready at http://localhost:${PORT}/"
 echo "  top page      -> http://localhost:${PORT}/"
+echo "  contact       -> http://localhost:${PORT}/contact/"
 echo "  elearning LP  -> http://localhost:${PORT}/lp/elearning/"
 echo "  ip LP         -> http://localhost:${PORT}/lp/ip/"
 echo "(Ctrl+C to stop)"

--- a/scripts/test-contact-redirect.mjs
+++ b/scripts/test-contact-redirect.mjs
@@ -80,6 +80,34 @@ test("does not retain disabled platform click IDs unless explicitly enabled", as
   });
 });
 
+test("preserves only valid attribution on every homepage contact link", async () => {
+  const { preserveAttributionOnContactLinks } = await loadModule();
+  const links = Array.from({ length: 3 }, () => ({
+    href: "https://docs.filma.biz/contact/",
+  }));
+  const document = {
+    querySelectorAll(selector) {
+      assert.equal(selector, "[data-contact-link]");
+      return links;
+    },
+  };
+
+  preserveAttributionOnContactLinks({
+    document,
+    location: {
+      search:
+        "?utm_source=google&utm_medium=cpc&utm_campaign=filma_sales_general_202608&utm_content=responsive_ad_a&utm_id=search_001&utm_term=video_drm&utm_source_platform=google_ads&gclid=AbC_123-xy&gad_source=1&gad_campaignid=1234567890&email=person%40example.com&next=https%3A%2F%2Fevil.example",
+    },
+  });
+
+  const expectedUrl =
+    "https://docs.filma.biz/contact/?utm_source=google&utm_medium=cpc&utm_campaign=filma_sales_general_202608&utm_content=responsive_ad_a&utm_id=search_001&utm_term=video_drm&utm_source_platform=google_ads&gclid=AbC_123-xy&gad_source=1&gad_campaignid=1234567890";
+  assert.deepEqual(
+    links.map((link) => link.href),
+    [expectedUrl, expectedUrl, expectedUrl],
+  );
+});
+
 test("builds a sanitized page URL and a form URL that receives only the management code", async () => {
   const {
     buildFormUrl,

--- a/scripts/test-homepage-pricing.mjs
+++ b/scripts/test-homepage-pricing.mjs
@@ -2,8 +2,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const html = await readFile(new URL("../index.html", import.meta.url), "utf8");
-const inquiryFormUrl =
-  "https://docs.google.com/forms/d/e/1FAIpQLSfTXvyTcaS_pHkpMvy8TqeNQpWhyQmFEopaFoI81n2swGNjmA/viewform";
+const contactPagePath = "/contact/";
 
 const expectedContent = [
   "DRMで守るべき動画コンテンツを配信する事業者へ",
@@ -31,9 +30,15 @@ for (const content of expectedContent) {
 }
 
 assert.equal(
-  html.split(`href="${inquiryFormUrl}"`).length - 1,
+  html.split(`href="${contactPagePath}"`).length - 1,
   3,
-  "All three inquiry buttons must link directly to the Google Form",
+  "All three inquiry buttons must route through the contact page",
+);
+
+assert.equal(
+  html.split("data-contact-link").length - 1,
+  3,
+  "All three inquiry buttons must preserve attribution parameters",
 );
 
 assert.ok(!html.includes("Pro（推奨）"), "Pro plan must not include the recommendation label");

--- a/scripts/test-preview-pages.mjs
+++ b/scripts/test-preview-pages.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createServer } from "node:net";
+import { fileURLToPath } from "node:url";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+
+async function reservePort() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
+async function waitForPreview(url, process) {
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    if (process.exitCode !== null) {
+      throw new Error(`Preview process exited with ${process.exitCode}`);
+    }
+
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // The preview server is still starting.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error("Preview server did not start");
+}
+
+const port = await reservePort();
+const preview = spawn("scripts/preview-pages", [String(port)], {
+  cwd: root,
+  stdio: "ignore",
+});
+
+try {
+  const baseUrl = `http://127.0.0.1:${port}`;
+  await waitForPreview(`${baseUrl}/`, preview);
+
+  const contactResponse = await fetch(`${baseUrl}/contact/`);
+  assert.equal(contactResponse.status, 200, "Preview must include /contact/");
+  assert.match(
+    await contactResponse.text(),
+    /\/assets\/js\/contact-redirect\.mjs/,
+  );
+
+  const moduleResponse = await fetch(
+    `${baseUrl}/assets/js/contact-redirect.mjs`,
+  );
+  assert.equal(
+    moduleResponse.status,
+    200,
+    "Preview must include the contact JavaScript module",
+  );
+} finally {
+  preview.kill("SIGTERM");
+  if (preview.exitCode === null) await once(preview, "exit");
+}
+
+console.log("Local Pages preview includes the contact flow.");


### PR DESCRIPTION
## 概要
トップページの3つの「導入のご相談」を、Googleフォーム直リンクから `/contact/` 経由へ切り替えます。

## 変更内容
- 3つのCTAを `/contact/` へ変更
- トップページURLの許可済みUTM 7項目とGoogle広告クリックIDをCTAへ引き渡し
- 個人情報や未知のクエリは引き渡さない
- JavaScript無効時も `/contact/` へ遷移するフォールバックを維持
- 現在の別タブ表示を維持

## 確認
- `node scripts/test-contact-redirect.mjs` — 10/10 passed
- `node scripts/test-homepage-pricing.mjs` — passed
- `git diff --check` — passed
- ローカルブラウザで3リンクへのUTM・クリックID引き渡しと、`email`・`next` の除外を確認